### PR TITLE
CDSID-1007 Temporary Fix for Tests

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -47,7 +47,7 @@ play.modules.enabled += "play.modules.reactivemongo.ReactiveMongoModule"
 play.http.errorHandler = "config.ErrorHandler"
 
 play.filters.headers.contentSecurityPolicy = "default-src 'self' 'unsafe-inline' localhost:9000 localhost:9032 localhost:9250 www.google-analytics.com www.googletagmanager.com tagmanager.google.com data: ssl.gstatic.com www.gstatic.com fonts.gstatic.com fonts.googleapis.com"
-play.filters.csrf.contentType.whiteList = ["application/xml", "application/json"]
+play.filters.csrf.contentType.whiteList = ["application/xml", "application/json", "multipart/form-data"]
 
 # Play Modules
 # ~~~~


### PR DESCRIPTION
This is a Temporary fix for the tests. It removes the CSRF protection of *all* endpoints which expect a Content-Type of `multipart/form-data`

This could be overridden in production-like environments with:
`play.filters.csrf.contentType.whiteList = ["application/xml", "application/json"]`