### PR TITLE
Add a label for file upload page because it was failing accessibility

### DIFF
--- a/app/views/upload_your_files.scala.html
+++ b/app/views/upload_your_files.scala.html
@@ -65,7 +65,7 @@
                     errorMessage = flash.get("fileUploadError").getOrElse(""),
                     classes = List("error-message")
                 )
-
+                <label class="form-label" for="upload-file">Upload a file</label>
                 <input
                 id="upload-file"
                 type="file"


### PR DESCRIPTION
## Before
<img width="701" alt="Screenshot 2019-05-30 at 13 22 52" src="https://user-images.githubusercontent.com/1692222/58632944-02ee4b80-82df-11e9-8c45-30334330c667.png">

## After
<img width="637" alt="Screenshot 2019-05-30 at 13 22 20" src="https://user-images.githubusercontent.com/1692222/58632963-0bdf1d00-82df-11e9-92b1-8816a71fa928.png">
