### PR TITLE
CEDS-2369 - implement cache clearance on start journey

### DIFF
--- a/app/Module.scala
+++ b/app/Module.scala
@@ -35,6 +35,7 @@ class Module extends AbstractModule {
     // Bind the actions for DI
     bind(classOf[AuthAction]).to(classOf[AuthActionImpl]).asEagerSingleton()
     bind(classOf[EORIRequiredAction]).to(classOf[EORIRequiredActionImpl]).asEagerSingleton()
+    bind(classOf[CacheDeleteAction]).to(classOf[CacheDeleteActionImpl]).asEagerSingleton()
     bind(classOf[ContactDetailsRequiredAction]).to(classOf[ContactDetailsRequiredActionImpl]).asEagerSingleton()
     bind(classOf[DataRetrievalAction]).to(classOf[DataRetrievalActionImpl]).asEagerSingleton()
     bind(classOf[Cache]).to(classOf[MongoCacheConnector]).asEagerSingleton()

--- a/app/connectors/Cache.scala
+++ b/app/connectors/Cache.scala
@@ -18,9 +18,9 @@ package connectors
 
 import com.google.inject.Inject
 import play.api.libs.json.Format
-import uk.gov.hmrc.http.cache.client.CacheMap
 import repositories.CacheMapRepository
-import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.http.cache.client.CacheMap
+import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
@@ -36,7 +36,7 @@ class MongoCacheConnector @Inject()(val repository: CacheMapRepository) extends 
   def getEntry[A](cacheId: String, key: String)(implicit hc: HeaderCarrier, fmt: Format[A]): Future[Option[A]] =
     fetch(cacheId).map(_.flatMap(_.getEntry(key)))
 
-  def remove()(implicit hc: HeaderCarrier): Unit =
+  def remove()(implicit hc: HeaderCarrier): Future[HttpResponse] =
     repository.remove()
 }
 
@@ -48,5 +48,5 @@ trait Cache {
 
   def getEntry[A](cacheId: String, key: String)(implicit hc: HeaderCarrier, fmt: Format[A]): Future[Option[A]]
 
-  def remove()(implicit hc: HeaderCarrier)
+  def remove()(implicit hc: HeaderCarrier): Future[HttpResponse]
 }

--- a/app/connectors/Cache.scala
+++ b/app/connectors/Cache.scala
@@ -35,6 +35,9 @@ class MongoCacheConnector @Inject()(val repository: CacheMapRepository) extends 
 
   def getEntry[A](cacheId: String, key: String)(implicit hc: HeaderCarrier, fmt: Format[A]): Future[Option[A]] =
     fetch(cacheId).map(_.flatMap(_.getEntry(key)))
+
+  def remove()(implicit hc: HeaderCarrier): Unit =
+    repository.remove()
 }
 
 trait Cache {
@@ -44,4 +47,6 @@ trait Cache {
   def fetch(cacheId: String)(implicit hc: HeaderCarrier): Future[Option[CacheMap]]
 
   def getEntry[A](cacheId: String, key: String)(implicit hc: HeaderCarrier, fmt: Format[A]): Future[Option[A]]
+
+  def remove()(implicit hc: HeaderCarrier)
 }

--- a/app/controllers/StartController.scala
+++ b/app/controllers/StartController.scala
@@ -16,16 +16,23 @@
 
 package controllers
 
+import controllers.actions.{AuthAction, CacheDeleteAction}
 import javax.inject.{Inject, Singleton}
 import play.api.i18n.I18nSupport
-import play.api.mvc.MessagesControllerComponents
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.play.bootstrap.controller.FrontendController
 import views.html.start
 
 @Singleton
-class StartController @Inject()(mcc: MessagesControllerComponents, start: start) extends FrontendController(mcc) with I18nSupport {
+class StartController @Inject()(authenticate: AuthAction, clearCache: CacheDeleteAction, mcc: MessagesControllerComponents, start: start)
+    extends FrontendController(mcc) with I18nSupport {
 
-  val displayStartPage = Action { implicit req =>
+  val displayStartPage: Action[AnyContent] = Action { implicit req =>
     Ok(start())
   }
+
+  def onStart: Action[AnyContent] = (authenticate andThen clearCache) { implicit req =>
+    Redirect(controllers.routes.ContactDetailsController.onPageLoad())
+  }
+
 }

--- a/app/controllers/actions/CacheDeleteAction.scala
+++ b/app/controllers/actions/CacheDeleteAction.scala
@@ -26,7 +26,7 @@ import uk.gov.hmrc.play.HeaderCarrierConverter
 import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
-class CacheDeleteActionImpl @Inject()(val dataCacheConnector: Cache, implicit val exc: ExecutionContext) extends CacheDeleteAction {
+class CacheDeleteActionImpl @Inject()(val dataCacheConnector: Cache)(implicit val exc: ExecutionContext) extends CacheDeleteAction {
   override def filter[A](request: AuthenticatedRequest[A]): Future[Option[Result]] = {
     implicit val hc: HeaderCarrier = HeaderCarrierConverter.fromHeadersAndSession(request.headers, Some(request.session))
 

--- a/app/controllers/actions/CacheDeleteAction.scala
+++ b/app/controllers/actions/CacheDeleteAction.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.actions
+
+import connectors.Cache
+import javax.inject.{Inject, Singleton}
+import models.requests.AuthenticatedRequest
+import play.api.mvc.{ActionFunction, Result}
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.play.HeaderCarrierConverter
+
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+class CacheDeleteAction @Inject()(val dataCacheConnector: Cache, val exc: ExecutionContext)
+    extends ActionFunction[AuthenticatedRequest, AuthenticatedRequest] {
+  override def invokeBlock[A](request: AuthenticatedRequest[A], block: AuthenticatedRequest[A] => Future[Result]): Future[Result] = {
+    implicit val hc: HeaderCarrier = HeaderCarrierConverter.fromHeadersAndSession(request.headers, Some(request.session))
+
+    dataCacheConnector.remove()
+    block(request)
+  }
+
+  override protected def executionContext: ExecutionContext = exc
+}

--- a/app/controllers/actions/CacheDeleteAction.scala
+++ b/app/controllers/actions/CacheDeleteAction.scala
@@ -26,11 +26,11 @@ import uk.gov.hmrc.play.HeaderCarrierConverter
 import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
-class CacheDeleteActionImpl @Inject()(val dataCacheConnector: Cache, val exc: ExecutionContext) extends CacheDeleteAction {
+class CacheDeleteActionImpl @Inject()(val dataCacheConnector: Cache, implicit val exc: ExecutionContext) extends CacheDeleteAction {
   override def filter[A](request: AuthenticatedRequest[A]): Future[Option[Result]] = {
     implicit val hc: HeaderCarrier = HeaderCarrierConverter.fromHeadersAndSession(request.headers, Some(request.session))
 
-    dataCacheConnector.remove().map(_ => None)(executionContext)
+    dataCacheConnector.remove().map(_ => None)
   }
 
   override protected def executionContext: ExecutionContext = exc

--- a/app/controllers/actions/CacheDeleteAction.scala
+++ b/app/controllers/actions/CacheDeleteAction.scala
@@ -19,21 +19,22 @@ package controllers.actions
 import connectors.Cache
 import javax.inject.{Inject, Singleton}
 import models.requests.AuthenticatedRequest
-import play.api.mvc.{ActionFunction, Result}
+import play.api.mvc.{ActionFilter, Result}
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.HeaderCarrierConverter
 
 import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
-class CacheDeleteAction @Inject()(val dataCacheConnector: Cache, val exc: ExecutionContext)
-    extends ActionFunction[AuthenticatedRequest, AuthenticatedRequest] {
-  override def invokeBlock[A](request: AuthenticatedRequest[A], block: AuthenticatedRequest[A] => Future[Result]): Future[Result] = {
+class CacheDeleteActionImpl @Inject()(val dataCacheConnector: Cache, val exc: ExecutionContext) extends CacheDeleteAction {
+  override def filter[A](request: AuthenticatedRequest[A]): Future[Option[Result]] = {
     implicit val hc: HeaderCarrier = HeaderCarrierConverter.fromHeadersAndSession(request.headers, Some(request.session))
 
     dataCacheConnector.remove()
-    block(request)
+    Future.successful(None)
   }
 
   override protected def executionContext: ExecutionContext = exc
 }
+
+trait CacheDeleteAction extends ActionFilter[AuthenticatedRequest]

--- a/app/controllers/actions/CacheDeleteAction.scala
+++ b/app/controllers/actions/CacheDeleteAction.scala
@@ -30,8 +30,7 @@ class CacheDeleteActionImpl @Inject()(val dataCacheConnector: Cache, val exc: Ex
   override def filter[A](request: AuthenticatedRequest[A]): Future[Option[Result]] = {
     implicit val hc: HeaderCarrier = HeaderCarrierConverter.fromHeadersAndSession(request.headers, Some(request.session))
 
-    dataCacheConnector.remove()
-    Future.successful(None)
+    dataCacheConnector.remove().map(_ => None)(executionContext)
   }
 
   override protected def executionContext: ExecutionContext = exc

--- a/app/views/components/submit_button.scala.html
+++ b/app/views/components/submit_button.scala.html
@@ -14,7 +14,7 @@
  * limitations under the License.
  *@
 
-@()(implicit messages: Messages)
+@(labelKey: String = "common.continue")(implicit messages: Messages)
 
-  <button id="submit" class="button">@messages("common.continue")</button>
+  <button id="submit" class="button">@messages(labelKey)</button>
 

--- a/app/views/start.scala.html
+++ b/app/views/start.scala.html
@@ -36,9 +36,11 @@
     <p>@Html(messages("startPage.paragraph4", bold(messages("startPage.paragraph4.bold"))))</p>
 </div>
 
-<a id="submit" class="button button-start" href="@{routes.ContactDetailsController.onPageLoad().url}" role="button">
-    @messages("common.button.startNow")
-</a>
+    @helper.form(action = routes.StartController.onStart()) {
+        @helper.CSRF.formField
+
+        @components.submit_button("common.button.startNow")
+    }
 
     @components.helpline_information()
 }

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -3,6 +3,7 @@
 GET         /assets/*file                       controllers.Assets.versioned(path="/public", file: Asset)
 
 GET         /start                              controllers.StartController.displayStartPage
+POST        /start                              controllers.StartController.onStart
 
 GET         /sign-out                           controllers.SignOutController.signOut
 

--- a/test/connectors/MongoCacheConnectorSpec.scala
+++ b/test/connectors/MongoCacheConnectorSpec.scala
@@ -133,4 +133,17 @@ class MongoCacheConnectorSpec extends SpecBase {
       }
     }
   }
+
+  ".remove" must {
+
+    "delegate to the CacheMapRepository" in {
+
+      val mockCacheMapRepository = mock[CacheMapRepository]
+      val mongoCacheConnector = new MongoCacheConnector(mockCacheMapRepository)
+
+      mongoCacheConnector.remove()
+
+      verify(mockCacheMapRepository).remove()
+    }
+  }
 }

--- a/test/controllers/StartControllerSpec.scala
+++ b/test/controllers/StartControllerSpec.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+
+import org.mockito.ArgumentMatchers._
+import org.mockito.Mockito.{reset, when}
+import play.api.test.Helpers._
+import play.twirl.api.HtmlFormat
+import views.html.start
+
+class StartControllerSpec extends ControllerSpecBase {
+
+  val page = mock[start]
+
+  def view(): String = page()(fakeRequest, messages).toString
+
+  def controller() =
+    new StartController(new FakeAuthAction(), new FakeCacheDeleteAction(), mcc, page)
+
+  override protected def beforeEach(): Unit = {
+    super.beforeEach
+
+    when(page.apply()(any(), any())).thenReturn(HtmlFormat.empty)
+  }
+
+  override protected def afterEach(): Unit = {
+    reset(page)
+
+    super.afterEach()
+  }
+
+  "Start controller" should {
+
+    "redirect to first page of journey" in {
+
+      val result = controller().onStart(fakeRequest)
+
+      status(result) mustBe SEE_OTHER
+      redirectLocation(result) mustBe Some(routes.ContactDetailsController.onPageLoad().url)
+
+    }
+
+  }
+}

--- a/test/controllers/actions/CacheDeleteActionSpec.scala
+++ b/test/controllers/actions/CacheDeleteActionSpec.scala
@@ -31,7 +31,7 @@ class CacheDeleteActionSpec extends ControllerSpecBase with SignedInUserGen {
   lazy val user = mock[SignedInUser]
   lazy val cache = mock[Cache]
 
-  def cacheDeleteAction = new CacheDeleteActionImpl(cache, executionContext)
+  def cacheDeleteAction = new CacheDeleteActionImpl(cache)
 
   "CacheDeleteAction" should {
 

--- a/test/controllers/actions/CacheDeleteActionSpec.scala
+++ b/test/controllers/actions/CacheDeleteActionSpec.scala
@@ -22,20 +22,22 @@ import generators.SignedInUserGen
 import models.requests.{AuthenticatedRequest, SignedInUser}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito._
+import uk.gov.hmrc.http.HttpResponse
 
-import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
 
 class CacheDeleteActionSpec extends ControllerSpecBase with SignedInUserGen {
 
   lazy val user = mock[SignedInUser]
   lazy val cache = mock[Cache]
-  lazy val ec = mock[ExecutionContext]
 
-  def cacheDeleteAction = new CacheDeleteActionImpl(cache, ec)
+  def cacheDeleteAction = new CacheDeleteActionImpl(cache, executionContext)
 
   "CacheDeleteAction" should {
 
-    "delegate to cache and executeblock" in {
+    "delegate to cache" in {
+
+      when(cache.remove()(any())) thenReturn Future.successful(HttpResponse(200))
 
       val request = AuthenticatedRequest(fakeRequest, user)
 

--- a/test/controllers/actions/CacheDeleteActionSpec.scala
+++ b/test/controllers/actions/CacheDeleteActionSpec.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.actions
+
+import connectors.Cache
+import controllers.ControllerSpecBase
+import generators.SignedInUserGen
+import models.requests.{AuthenticatedRequest, SignedInUser}
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito._
+
+import scala.concurrent.ExecutionContext
+
+class CacheDeleteActionSpec extends ControllerSpecBase with SignedInUserGen {
+
+  lazy val user = mock[SignedInUser]
+  lazy val cache = mock[Cache]
+  lazy val ec = mock[ExecutionContext]
+
+  def cacheDeleteAction = new CacheDeleteActionImpl(cache, ec)
+
+  "CacheDeleteAction" should {
+
+    "delegate to cache and executeblock" in {
+
+      val request = AuthenticatedRequest(fakeRequest, user)
+
+      cacheDeleteAction.filter(request)
+
+      verify(cache).remove()(any())
+    }
+  }
+
+}

--- a/test/controllers/actions/FakeActions.scala
+++ b/test/controllers/actions/FakeActions.scala
@@ -58,4 +58,9 @@ trait FakeActions extends Generators {
     override protected def refine[A](request: OptionalDataRequest[A]): Future[Either[Result, ContactDetailsRequest[A]]] =
       Future.successful(Right(ContactDetailsRequest(request.request, UserAnswers(cacheMap), contactDetails)))
   }
+
+  class FakeCacheDeleteAction extends CacheDeleteAction {
+    override protected def filter[A](request: AuthenticatedRequest[A]): Future[Option[Result]] = Future.successful(None)
+    override protected def executionContext: ExecutionContext = ExecutionContext.global
+  }
 }

--- a/test/views/StartSpec.scala
+++ b/test/views/StartSpec.scala
@@ -17,6 +17,7 @@
 package views
 
 import controllers.routes
+import utils.FakeRequestCSRFSupport._
 import views.behaviours.ViewBehaviours
 import views.html.start
 
@@ -24,7 +25,7 @@ class StartSpec extends DomAssertions with ViewBehaviours {
 
   val page = instanceOf[start]
 
-  val view = () => page()(fakeRequest, messages)
+  val view = () => page()(fakeRequest.withCSRFToken, messages)
 
   val messageKeyPrefix = "startPage"
 
@@ -32,9 +33,12 @@ class StartSpec extends DomAssertions with ViewBehaviours {
     behave like normalPage(view, messageKeyPrefix, "paragraph2", "p.youWillNeed", "listItem1", "listItem2", "listItem3")
     "have a start button with correct link" in {
       val doc = asDocument(view())
-      val expectedLink = routes.ContactDetailsController.onPageLoad().url
+      val expectedLink = routes.StartController.onStart().url
 
-      assertContainsLink(doc, messages("common.button.startNow"), expectedLink)
+      val form = doc.getElementsByTag("form").first()
+      form.attr("action") mustBe expectedLink
+
+      form.getElementsByTag("button").text() mustBe messages("common.button.startNow")
     }
 
     "have paragraph3 with bold text" in {


### PR DESCRIPTION
I've done some experimenting with implementing an Action to clear the cache.  I needed to add a new endpoint to cause this to be triggered so I created one (POST /start) which just ensures the user is logged in, clears the cache and then redirects to the first step (Contact Address).

Only tested manually so far with two users in two different browsers.