### PR TITLE
CEDS-2659 Upgrade SBT to 1.3.6

### DIFF
--- a/app/connectors/CdsFileUploadConnector.scala
+++ b/app/connectors/CdsFileUploadConnector.scala
@@ -20,6 +20,7 @@ import config.{AppConfig, CDSFileUpload}
 import javax.inject.Inject
 import models.Notification
 import play.api.Logger
+import uk.gov.hmrc.http.HttpReads.Implicits._
 import uk.gov.hmrc.http.{HeaderCarrier, HttpClient}
 
 import scala.concurrent.{ExecutionContext, Future}

--- a/app/connectors/CustomsDeclarationsConnector.scala
+++ b/app/connectors/CustomsDeclarationsConnector.scala
@@ -22,6 +22,7 @@ import models.{FileUploadRequest, FileUploadResponse}
 import play.api.Logger
 import play.api.http.{ContentTypes, HeaderNames}
 import play.api.mvc.Codec
+import uk.gov.hmrc.http.HttpReads.Implicits._
 import uk.gov.hmrc.http.{HeaderCarrier, HttpClient, HttpResponse}
 
 import scala.concurrent.{ExecutionContext, Future}

--- a/app/controllers/test/CustomsDeclarationsStubController.scala
+++ b/app/controllers/test/CustomsDeclarationsStubController.scala
@@ -22,6 +22,7 @@ import models.Field._
 import models._
 import play.api.http.{ContentTypes, HeaderNames}
 import play.api.mvc.{Action, Codec, MessagesControllerComponents}
+import uk.gov.hmrc.http.HttpReads.Implicits._
 import uk.gov.hmrc.http.{HeaderCarrier, HttpClient, HttpResponse}
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 

--- a/build.sbt
+++ b/build.sbt
@@ -12,6 +12,7 @@ resolvers += Resolver.bintrayRepo("wolfendale", "maven")
 
 lazy val microservice = (project in file("."))
   .enablePlugins(play.sbt.PlayScala, SbtAutoBuildPlugin, SbtGitVersioning, SbtDistributablesPlugin, SbtArtifactory)
+  .settings(libraryDependencies ++= compileDependencies ++ testDependencies)
   .settings(scalaVersion := "2.12.12")
   .settings(publishingSettings: _*)
   .settings(resolvers += Resolver.jcenterRepo)
@@ -32,6 +33,7 @@ lazy val microservice = (project in file("."))
     includeFilter in uglify := GlobFilter("cdsfileuploadfrontend-*.js")
   )
   .settings(silencerSettings)
+  .disablePlugins(JUnitXmlReportPlugin) //Required to prevent https://github.com/scalatest/scalatest/issues/1427
 
 val httpComponentsVersion = "4.5.11"
 
@@ -60,8 +62,6 @@ val testDependencies = Seq(
   "wolfendale"                %%  "scalacheck-gen-regexp"    % "0.1.1"     % "test",
   "com.github.tomakehurst"    %   "wiremock-standalone"      % "2.22.0"    % "test"
 )
-
-libraryDependencies ++= compileDependencies ++ testDependencies
 
 lazy val silencerSettings: Seq[Setting[_]] = {
   val silencerVersion = "1.7.0"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.18
+sbt.version=1.3.6

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,22 +6,22 @@ resolvers += "HMRC Releases" at "https://dl.bintray.com/hmrc/releases"
 resolvers += Resolver.typesafeRepo("releases")
 
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "2.6.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "2.10.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "2.1.0")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "1.2.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "1.6.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.0.0")
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.23")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.24")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-web" % "1.4.3")
 
-addSbtPlugin("net.ground5hark.sbt" % "sbt-concat" % "0.1.9")
+addSbtPlugin("net.ground5hark.sbt" % "sbt-concat" % "0.2.0")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-uglify" % "2.0.0")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-digest" % "1.1.2")
+addSbtPlugin("com.typesafe.sbt" % "sbt-digest" % "1.1.4")
 
 addSbtPlugin("com.lucidchart" % "sbt-scalafmt" % "1.16")


### PR DESCRIPTION
This version seems to be the last reliable version.
Higher versions contain some issues with importing a project. That would
need additional steps and workarounds to make it work.