### PR TITLE
CEDS-2770 New GTM rollout approach

### DIFF
--- a/app/config/AppConfig.scala
+++ b/app/config/AppConfig.scala
@@ -20,20 +20,19 @@ import pureconfig.{CamelCase, ConfigFieldMapping, KebabCase}
 import pureconfig.generic.ProductHint
 
 case class AppConfig(
-                      appName: String,
-                      developerHubClientId: String,
-                      contactFrontend: ContactFrontend,
-                      assets: Assets,
-                      googleAnalytics: GoogleAnalytics,
-                      microservice: Microservice,
-                      fileFormats: FileFormats,
-                      notifications: Notifications,
-                      feedback: Feedback,
-                      proxy: Proxy,
-                      accessibilityLinkUrl: String,
-                      answersRepository: AnswersRepository,
-                      gtmCustoms: GtmCustoms,
-                      trackingConsentFrontend: TrackingConsentFrontend
+  appName: String,
+  developerHubClientId: String,
+  contactFrontend: ContactFrontend,
+  assets: Assets,
+  googleAnalytics: GoogleAnalytics,
+  microservice: Microservice,
+  fileFormats: FileFormats,
+  notifications: Notifications,
+  feedback: Feedback,
+  proxy: Proxy,
+  accessibilityLinkUrl: String,
+  answersRepository: AnswersRepository,
+  trackingConsentFrontend: TrackingConsentFrontend
 )
 
 object AppConfig {
@@ -92,6 +91,6 @@ case class Proxy(protocol: String, host: String, port: Int, username: String, pa
 
 case class AnswersRepository(ttlSeconds: Int)
 
-case class GtmCustoms(container: String)
+case class Gtm(container: String)
 
-case class TrackingConsentFrontend(url: String)
+case class TrackingConsentFrontend(gtm: Gtm, url: String)

--- a/app/config/AppConfig.scala
+++ b/app/config/AppConfig.scala
@@ -20,18 +20,20 @@ import pureconfig.{CamelCase, ConfigFieldMapping, KebabCase}
 import pureconfig.generic.ProductHint
 
 case class AppConfig(
-  appName: String,
-  developerHubClientId: String,
-  contactFrontend: ContactFrontend,
-  assets: Assets,
-  googleAnalytics: GoogleAnalytics,
-  microservice: Microservice,
-  fileFormats: FileFormats,
-  notifications: Notifications,
-  feedback: Feedback,
-  proxy: Proxy,
-  accessibilityLinkUrl: String,
-  answersRepository: AnswersRepository
+                      appName: String,
+                      developerHubClientId: String,
+                      contactFrontend: ContactFrontend,
+                      assets: Assets,
+                      googleAnalytics: GoogleAnalytics,
+                      microservice: Microservice,
+                      fileFormats: FileFormats,
+                      notifications: Notifications,
+                      feedback: Feedback,
+                      proxy: Proxy,
+                      accessibilityLinkUrl: String,
+                      answersRepository: AnswersRepository,
+                      gtmCustoms: GtmCustoms,
+                      trackingConsentFrontend: TrackingConsentFrontend
 )
 
 object AppConfig {
@@ -89,3 +91,7 @@ case class Feedback(url: String)
 case class Proxy(protocol: String, host: String, port: Int, username: String, password: String, proxyRequiredForThisEnvironment: Boolean)
 
 case class AnswersRepository(ttlSeconds: Int)
+
+case class GtmCustoms(container: String)
+
+case class TrackingConsentFrontend(url: String)

--- a/app/views/govuk_wrapper.scala.html
+++ b/app/views/govuk_wrapper.scala.html
@@ -108,10 +108,12 @@
     }
 
     @content = {
-            <!-- Google Tag Manager (noscript) -->
-        <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-NDJKHWK" height="0" width="0" style="display: none;
-            visibility: hidden"></iframe></noscript>
-            <!-- End Google Tag Manager (noscript) -->
+            <!--[if !IE]>-->
+        <script type="text/javascript"
+        src="@{appConfig.trackingConsentFrontend.url}"
+        id="tracking-consent-script-tag"
+        data-gtm-container="@{appConfig.gtmCustoms.container}"></script>
+            <!--<![endif]-->
 
     @main_content_di(
         article = mainContent,

--- a/app/views/govuk_wrapper.scala.html
+++ b/app/views/govuk_wrapper.scala.html
@@ -108,12 +108,12 @@
     }
 
     @content = {
-            <!--[if !IE]>-->
-        <script type="text/javascript"
-        src="@{appConfig.trackingConsentFrontend.url}"
-        id="tracking-consent-script-tag"
-        data-gtm-container="@{appConfig.gtmCustoms.container}"></script>
-            <!--<![endif]-->
+        <!--[if !IE]>-->
+            <script type="text/javascript"
+                src="@{appConfig.trackingConsentFrontend.url}"
+                id="tracking-consent-script-tag"
+                data-gtm-container="@{appConfig.trackingConsentFrontend.gtm.container}"></script>
+        <!--<![endif]-->
 
     @main_content_di(
         article = mainContent,

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -212,8 +212,7 @@ answers-repository {
 allowList.eori = []
 
 # Google Tag Manager (GTM) configuration
-#        - tracking-consent-frontend.url will be overwritten by the app-config-common repo
-gtm-customs.container = "a"
 tracking-consent-frontend {
-  url = "http://localhost:6793/tracking-consent/tracking.js"
+  gtm.container = "a"
+  url = "http://localhost:12345/tracking-consent/tracking.js"
 }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -210,3 +210,10 @@ answers-repository {
 }
 
 allowList.eori = []
+
+# Google Tag Manager (GTM) configuration
+#        - tracking-consent-frontend.url will be overwritten by the app-config-common repo
+gtm-customs.container = "a"
+tracking-consent-frontend {
+  url = "http://localhost:6793/tracking-consent/tracking.js"
+}

--- a/test/config/AppConfigSpec.scala
+++ b/test/config/AppConfigSpec.scala
@@ -44,5 +44,17 @@ class AppConfigSpec extends PlaySpec {
 
       cdsFileUpload.fetchNotificationEndpoint(fileReference) mustBe expectedUrl
     }
+
+    "have gtm container" in {
+
+        config.gtmCustoms.container mustBe "a"
+    }
+
+    "have tracking-consent-frontend url" in {
+
+      val expectedUrl = "http://localhost:6793/tracking-consent/tracking.js"
+
+      config.trackingConsentFrontend.url mustBe expectedUrl
+    }
   }
 }

--- a/test/config/AppConfigSpec.scala
+++ b/test/config/AppConfigSpec.scala
@@ -47,12 +47,12 @@ class AppConfigSpec extends PlaySpec {
 
     "have gtm container" in {
 
-        config.gtmCustoms.container mustBe "a"
+      config.trackingConsentFrontend.gtm.container mustBe "a"
     }
 
     "have tracking-consent-frontend url" in {
 
-      val expectedUrl = "http://localhost:6793/tracking-consent/tracking.js"
+      val expectedUrl = "http://localhost:12345/tracking-consent/tracking.js"
 
       config.trackingConsentFrontend.url mustBe expectedUrl
     }


### PR DESCRIPTION
All frontend HMRC services need to implement a cookie banner and this
changes the way we setup GTM (Google Tag Manager) into our services.
This is a centralised HRMC approach.

The container "a" has been provided by Alex Stanton, our performance
analyst.