### PR TITLE
CEDS-2746 Add phase_banner view component

### DIFF
--- a/app/config/AppConfig.scala
+++ b/app/config/AppConfig.scala
@@ -16,13 +16,12 @@
 
 package config
 
-import pureconfig.{CamelCase, ConfigFieldMapping, KebabCase}
 import pureconfig.generic.ProductHint
+import pureconfig.{CamelCase, ConfigFieldMapping, KebabCase}
 
 case class AppConfig(
   appName: String,
   developerHubClientId: String,
-  contactFrontend: ContactFrontend,
   assets: Assets,
   googleAnalytics: GoogleAnalytics,
   microservice: Microservice,
@@ -44,11 +43,6 @@ object AppConfig {
   })
 }
 
-case class ContactFrontend(host: String, serviceIdentifier: String = "MyService") {
-  lazy val reportAProblemPartialUrl = s"$host/contact/problem_reports_ajax?service=$serviceIdentifier"
-  lazy val reportAProblemNonJSUrl = s"$host/contact/problem_reports_nonjs?service=$serviceIdentifier"
-}
-
 case class Assets(version: String, url: String) {
   lazy val prefix: String = s"$url$version"
 }
@@ -61,7 +55,8 @@ case class Services(
   customsDeclarations: CustomsDeclarations,
   cdsFileUploadFrontend: CDSFileUploadFrontend,
   cdsFileUpload: CDSFileUpload,
-  keystore: Keystore
+  keystore: Keystore,
+  contactFrontend: ContactFrontend
 )
 
 case class CustomsDeclarations(protocol: Option[String], host: String, port: Option[Int], batchUploadUri: String, apiVersion: String) {
@@ -79,6 +74,13 @@ case class CDSFileUpload(protocol: Option[String], host: String, port: Option[In
 
 case class Keystore(protocol: String = "https", host: String, port: Int, defaultSource: String, domain: String) {
   lazy val baseUri: String = s"$protocol://$host:$port"
+}
+
+case class ContactFrontend(protocol: String = "https", host: String, port: Option[Int], serviceId: String) {
+  lazy val giveFeedbackLink: String = {
+    val contactFrontendBaseUrl = s"$protocol://$host:${port.getOrElse(443)}"
+    s"$contactFrontendBaseUrl/contact/beta-feedback-unauthenticated?service=$serviceId"
+  }
 }
 
 case class FileFormats(maxFileSizeMb: Int, approvedFileTypes: String, approvedFileExtensions: String)

--- a/app/views/components/phase_banner.scala.html
+++ b/app/views/components/phase_banner.scala.html
@@ -1,0 +1,37 @@
+@*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import config.AppConfig
+
+@this(appConfig: AppConfig)
+
+@(phase: String)(implicit request: Request[_], messages: Messages)
+
+@protocol = @{ if(request.secure) "https" else "http" }
+@betaFeedbackUrl = @{s"${appConfig.microservice.services.contactFrontend.giveFeedbackLink}&backUrl=$protocol://${request.host}${request.uri}"}
+
+@link = {<a href="@betaFeedbackUrl">@messages("common.feedback.link")</a>}
+
+@feedbackBanner = {
+  @Html(messages("common.feedback", link))
+}
+
+<div class="phase-banner">
+  <p>
+    <strong class="phase-tag">@messages("common.phase")</strong>
+    <span>@feedbackBanner</span>
+  </p>
+</div>

--- a/app/views/govuk_wrapper.scala.html
+++ b/app/views/govuk_wrapper.scala.html
@@ -29,7 +29,8 @@
     footer_links_di: FooterLinks,
     reportAProblemLink: ReportAProblemLink,
     hmrc_gov_uk_template: GovUkTemplate,
-    appConfig: AppConfig
+    appConfig: AppConfig,
+    phaseBanner: components.phase_banner
 )
 
 @(title: String,
@@ -91,20 +92,12 @@
 
     @mainContentHeader = {
         <div id="global-header-bar"></div>
-        <div class="phase-banner">
-            <p>
-                <strong class="phase-tag">@Messages("common.phase")</strong>
-                <span>@messages("common.feedbackFirst") <a href="@appConfig.feedback.url">@messages("common.feedbackSecond")</a>
-                    @messages("common.feedbackThird")</span>
-            </p>
-        </div>
-    @if(contentHeader.isDefined) {
-        @main_content_header_di(contentHeader = contentHeader.get)
-    }
-    }
 
-    @getHelpForm = @{
-        reportAProblemLink(appConfig.contactFrontend.reportAProblemPartialUrl, appConfig.contactFrontend.reportAProblemNonJSUrl)
+        @phaseBanner("beta")
+
+        @if(contentHeader.isDefined) {
+            @main_content_header_di(contentHeader = contentHeader.get)
+        }
     }
 
     @content = {

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -118,6 +118,13 @@ microservice {
         port = 6795
         fetch-notification-uri = /cds-file-upload/notification
       }
+
+      contact-frontend {
+        protocol = http
+        host = localhost
+        port = 9250
+        service-id = "SFUS"
+      }
     }
 }
 
@@ -170,10 +177,6 @@ assets {
   version = "3.7.0"
   version = ${?ASSETS_FRONTEND_VERSION}
   url = "http://localhost:9032/assets/"
-}
-
-contact-frontend {
-  host = "http://localhost:9250"
 }
 
 file-formats {

--- a/conf/messages
+++ b/conf/messages
@@ -1,11 +1,11 @@
 ## common
 common.service.name=Upload a customs document
 common.phase=Beta
-common.feedbackFirst=This is a new service - your
-common.feedbackSecond=feedback
-common.feedbackThird=will help us to improve it.
 common.continue=Continue
 cds.sign.out=Sign out
+
+common.feedback=This is a new service - your {0} will help us to improve it.
+common.feedback.link=feedback
 
 ## errors
 error.browser.title.prefix=Error:

--- a/test/base/Injector.scala
+++ b/test/base/Injector.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package utils
+package base
 
 import com.codahale.metrics.SharedMetricRegistries
 import play.api.inject.guice.GuiceApplicationBuilder

--- a/test/base/SpecBase.scala
+++ b/test/base/SpecBase.scala
@@ -28,7 +28,6 @@ import play.api.i18n.{Lang, Messages, MessagesApi}
 import play.api.mvc.MessagesControllerComponents
 import play.api.test.FakeRequest
 import uk.gov.hmrc.http.HeaderCarrier
-import utils.Injector
 
 import scala.concurrent.ExecutionContext
 

--- a/test/base/UnitViewSpec.scala
+++ b/test/base/UnitViewSpec.scala
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package base
+
+import org.jsoup.nodes.Document
+import org.scalatest.Assertion
+import org.scalatest.matchers.{BeMatcher, MatchResult}
+import play.api.i18n.{Lang, Messages, MessagesApi}
+import play.api.mvc.{AnyContent, Request}
+import play.api.test.FakeRequest
+import views.matchers.ViewMatchers
+
+class UnitViewSpec extends UnitSpec with ViewMatchers {
+
+  import utils.FakeRequestCSRFSupport._
+
+  implicit val request: Request[AnyContent] = FakeRequest().withCSRFToken
+
+  protected implicit def messages(implicit request: Request[_]): Messages =
+    new AllMessageKeysAreMandatoryMessages(realMessagesApi.preferred(request))
+
+  protected def messages(key: String, args: Any*)(implicit request: Request[_]): String = messages(request)(key, args: _*)
+
+  val realMessagesApi = UnitViewSpec.realMessagesApi
+
+  def checkErrorsSummary(view: Document): Assertion = {
+    view.getElementById("error-summary-heading").text() must be("error.summary.title")
+    view.getElementsByClass("error-summary error-summary--show").get(0).getElementsByTag("p").text() must be("error.summary.text")
+  }
+}
+
+class MessagesKeyMatcher(key: String) extends BeMatcher[String] {
+  override def apply(left: String): MatchResult =
+    if (left == key) {
+      val missing = MessagesKeyMatcher.langs.find(lang => !UnitViewSpec.realMessagesApi.isDefinedAt(key)(lang))
+      val language = missing.map(_.toLocale.getDisplayLanguage())
+      MatchResult(
+        missing.isEmpty,
+        s"${language.getOrElse("None of languages")} does not have translation for $key",
+        s"$key have translation for ${language.getOrElse("every language")}"
+      )
+    } else {
+      MatchResult(matches = false, s"$left is not $key", s"$left is $key")
+    }
+}
+
+object MessagesKeyMatcher {
+  val langs: Seq[Lang] = Seq(Lang("en"))
+}
+
+object UnitViewSpec extends Injector {
+  val realMessagesApi: MessagesApi = instanceOf[MessagesApi]
+}

--- a/test/config/AppConfigSpec.scala
+++ b/test/config/AppConfigSpec.scala
@@ -16,12 +16,11 @@
 
 package config
 
-import org.scalatestplus.play.{PlaySpec}
+import org.scalatestplus.play.PlaySpec
+import pureconfig.ConfigSource
+import pureconfig.generic.auto._
 
 class AppConfigSpec extends PlaySpec {
-
-  import pureconfig.ConfigSource
-  import pureconfig.generic.auto._
 
   val config = ConfigSource.default.loadOrThrow[AppConfig]
 
@@ -55,6 +54,13 @@ class AppConfigSpec extends PlaySpec {
       val expectedUrl = "http://localhost:12345/tracking-consent/tracking.js"
 
       config.trackingConsentFrontend.url mustBe expectedUrl
+    }
+
+    "have link to contact-frontend" in {
+
+      val expectedUrl = "http://localhost:9250/contact/beta-feedback-unauthenticated?service=SFUS"
+
+      config.microservice.services.contactFrontend.giveFeedbackLink mustBe expectedUrl
     }
   }
 }

--- a/test/connectors/CdsFileUploadConnectorSpec.scala
+++ b/test/connectors/CdsFileUploadConnectorSpec.scala
@@ -16,7 +16,7 @@
 
 package connectors
 
-import base.UnitSpec
+import base.{Injector, UnitSpec}
 import config.AppConfig
 import models.Notification
 import org.mockito.ArgumentMatchers.any
@@ -24,7 +24,6 @@ import org.mockito.Mockito.{reset, when}
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.concurrent.ScalaFutures
 import uk.gov.hmrc.http.{HeaderCarrier, HttpClient}
-import utils.Injector
 
 import scala.concurrent.ExecutionContext.global
 import scala.concurrent.Future

--- a/test/views/components/PhaseBannerSpec.scala
+++ b/test/views/components/PhaseBannerSpec.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views.components
+
+import base.{Injector, UnitViewSpec}
+import config.AppConfig
+import play.api.test.FakeRequest
+import play.twirl.api.Html
+import views.html.components.phase_banner
+
+class PhaseBannerSpec extends UnitViewSpec with Injector {
+
+  private val bannerPartial = instanceOf[phase_banner]
+
+  private val requestPath = "/customs-declare-exports/any-page"
+  private implicit val fakeRequest = FakeRequest("GET", requestPath)
+
+  private def createBanner(): Html = bannerPartial("")(fakeRequest, messages)
+
+  "phaseBanner" should {
+
+    "display feedback link with correct href" in {
+
+      val appConfig = instanceOf[AppConfig]
+      val expectedHrefValue = s"${appConfig.microservice.services.contactFrontend.giveFeedbackLink}&backUrl=http://localhost$requestPath"
+
+      createBanner().getElementsByClass("phase-banner").first().getElementsByTag("a").first() must haveHref(expectedHrefValue)
+    }
+  }
+
+}

--- a/test/views/matchers/ViewMatchers.scala
+++ b/test/views/matchers/ViewMatchers.scala
@@ -1,0 +1,374 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views.matchers
+
+import org.jsoup.Jsoup
+import org.jsoup.nodes.{Document, Element}
+import org.jsoup.select.Elements
+import org.scalatest.MustMatchers
+import org.scalatest.matchers._
+import play.api.i18n.Messages
+import play.api.mvc.{Call, Result}
+import play.api.test.Helpers.{contentAsString, _}
+import play.twirl.api.Html
+
+import scala.collection.JavaConverters._
+import scala.concurrent.Future
+import scala.util.Try
+
+//noinspection ScalaStyle
+trait ViewMatchers {
+
+  implicit private def elements2Scala(elements: Elements): Iterator[Element] = elements.iterator().asScala
+  implicit protected def htmlBodyOf(html: Html): Document = Jsoup.parse(html.toString())
+  implicit protected def htmlBodyOf(page: String): Document = Jsoup.parse(page)
+  implicit protected def htmlBodyOf(result: Future[Result]): Document = htmlBodyOf(contentAsString(result))
+
+  implicit class PageComplexChecks(document: Document) extends MustMatchers {
+    def checkErrorsSummary(): Unit = {
+      document.getElementById("error-summary-heading").text() mustBe "error.summary.title"
+      document.select("div.error-summary.error-summary--show>p").text() must be("error.summary.text")
+    }
+  }
+
+  def containElementWithID(id: String): Matcher[Element] = new ContainElementWithIDMatcher(id)
+
+  def containElementWithClass(name: String): Matcher[Element] = new ContainElementWithClassMatcher(name)
+
+  def containErrorElementWithTagAndHref(tag: String, href: String): Matcher[Element] = new ContainErrorElementWithClassMatcher(tag, href)
+
+  def containErrorElementWithMessage(text: String): Matcher[Element] = new ContainErrorElementWithMessage(text)
+  def containErrorElementWithMessageKey(key: String)(implicit messages: Messages): Matcher[Element] =
+    new ContainErrorElementWithMessage(messages(key))
+
+  def containElementWithAttribute(key: String, value: String): Matcher[Element] =
+    new ContainElementWithAttribute(key, value)
+
+  def containElementWithTag(tag: String): Matcher[Element] = new ContainElementWithTagMatcher(tag)
+
+  def containText(text: String): Matcher[Element] = new ElementContainsTextMatcher(text)
+
+  def containMessage(key: String, args: Any*)(implicit messages: Messages): Matcher[Element] =
+    new ElementContainsMessageMatcher(key, args)
+
+  def containMessageForElements(key: String, args: Any*)(implicit messages: Messages): Matcher[Elements] =
+    new ElementsContainsMessageMatcher(key, args)
+
+  def beSelected: Matcher[Element] = new ElementSelectedMatcher(true)
+
+  def haveClass(text: String): Matcher[Element] = new ElementHasClassMatcher(text)
+
+  def containHtml(text: String): Matcher[Element] = new ElementContainsHtmlMatcher(text)
+
+  def haveSize(size: Int): Matcher[Elements] = new ElementsHasSizeMatcher(size)
+
+  def haveAttribute(key: String, value: String): Matcher[Element] = new ElementHasAttributeValueMatcher(key, value)
+
+  def haveAttribute(key: String): Matcher[Element] = new ElementHasAttributeMatcher(key)
+
+  def haveId(value: String): Matcher[Element] = new ElementHasAttributeValueMatcher("id", value)
+
+  def haveHref(value: String): Matcher[Element] = new ElementHasAttributeValueMatcher("href", value)
+
+  def haveHref(value: Call): Matcher[Element] = new ElementHasAttributeValueMatcher("href", value.url)
+
+  def haveTag(tag: String): Matcher[Element] = new ElementTagMatcher(tag)
+
+  def haveSummaryKey(value: String) = new ElementsHasElementsContainingTextMatcher("govuk-summary-list__key", value)
+  def haveSummaryValue(value: String) = new ElementsHasElementsContainingTextMatcher("govuk-summary-list__value", value)
+  def haveSummaryActionsText(value: String) = new ElementsHasElementsContainingTextMatcher("govuk-summary-list__actions", value)
+  def haveSummaryActionsTexts(label: String, hint: String, hintArgs: String*)(implicit messages: Messages) =
+    haveSummaryActionsText(s"${messages(label)} ${messages(hint, hintArgs: _*)}")
+  def haveSummaryActionsHref(value: Call) = new ElementsHasSummaryActionMatcher(value)
+
+  def haveChildCount(count: Int): Matcher[Element] = new ElementHasChildCountMatcher(count)
+
+  def containElement(tag: String) = new ChildMatcherBuilder(tag)
+
+  def haveFieldError(fieldName: String, content: String): Matcher[Element] =
+    new ContainElementWithIDMatcher(s"error-message-$fieldName-input") and new ElementContainsFieldError(fieldName, content)
+
+  def haveGovukFieldError(fieldName: String, content: String): Matcher[Element] =
+    new ContainElementWithIDMatcher(s"$fieldName-error") and new ElementContainsGovukFieldError(fieldName, content)
+
+  def haveFieldErrorLink(fieldName: String, link: String): Matcher[Element] =
+    new ElementContainsFieldErrorLink(fieldName, link)
+
+  def haveGlobalErrorSummary: Matcher[Document] = new ContainElementWithIDMatcher("error-summary-heading")
+
+  def haveGovukGlobalErrorSummary: Matcher[Document] = new ContainElementWithClassMatcher("govuk-error-summary")
+
+  def test: Matcher[Document] = new ContainErrorElementWithClassMatcher("govuk-list govuk-error-summary__list", "#value")
+
+  def haveTranslationFor(key: String): Matcher[Messages] = new TranslationKeyMatcher(key)
+
+  def submitTo(path: String): Matcher[Element] = new FormSubmitTo(path)
+
+  def submitTo(call: Call): Matcher[Element] = new FormSubmitTo(call.url)
+
+  private def actualContentWas(node: Element): String =
+    if (node == null) {
+      "Element did not exist"
+    } else {
+      s"\nActual content was:\n${node.html}\n"
+    }
+
+  private def actualContentWas(node: Elements): String =
+    if (node == null) {
+      "Elements did not exist"
+    } else {
+      s"\nActual content was:\n${node.html}\n"
+    }
+
+  class TranslationKeyMatcher(key: String) extends Matcher[Messages] {
+    override def apply(left: Messages): MatchResult = MatchResult(
+      matches = left.isDefinedAt(key),
+      rawFailureMessage = s"$key is not defined in Messages",
+      rawNegatedFailureMessage = s"$key is defined in Messages"
+    )
+  }
+
+  class ContainElementWithIDMatcher(id: String) extends Matcher[Element] {
+    override def apply(left: Element): MatchResult =
+      MatchResult(
+        left != null && left.getElementById(id) != null,
+        s"Document did not contain element with ID {$id}\n${actualContentWas(left)}",
+        s"Document contained an element with ID {$id}"
+      )
+  }
+
+  class ContainElementWithClassMatcher(name: String) extends Matcher[Element] {
+    override def apply(left: Element): MatchResult =
+      MatchResult(
+        left != null && left.getElementsByClass(name).size() > 0,
+        s"Document did not contain element with class {$name}\n${actualContentWas(left)}",
+        s"Document contained an element with class {$name}"
+      )
+  }
+
+  class ContainErrorElementWithClassMatcher(tag: String, href: String) extends Matcher[Element] {
+    override def apply(left: Element): MatchResult =
+      MatchResult(
+        left != null && left.getElementsByClass("govuk-list govuk-error-summary__list").get(0).getElementsByTag(tag).eachAttr("href").contains(href),
+        s"Document did not contain element with class {$tag}\n${actualContentWas(left)}",
+        s"Document contained an element with class {$tag}"
+      )
+  }
+
+  class ContainErrorElementWithMessage(text: String) extends Matcher[Element] {
+    override def apply(left: Element): MatchResult =
+      MatchResult(
+        left != null && left.getElementsByClass("govuk-error-summary__list").text().contains(text),
+        s"Document did not contain error element with message {$text}\n${actualContentWas(left)}",
+        s"Document contained an error element with message {$text}"
+      )
+  }
+
+  class ElementSelectedMatcher(expected: Boolean) extends Matcher[Element] {
+    override def apply(left: Element): MatchResult = {
+      val isChecked = left.getElementsByAttribute("checked").size() == 1
+      MatchResult(left != null && isChecked == expected, s"Element was not selected\n${actualContentWas(left)}", "Element was selected")
+    }
+  }
+
+  class ContainElementWithAttribute(key: String, value: String) extends Matcher[Element] {
+    override def apply(left: Element): MatchResult =
+      MatchResult(
+        left != null && !left.getElementsByAttributeValue(key, value).isEmpty,
+        s"Document did not contain element with Attribute {$key=$value}\n${actualContentWas(left)}",
+        s"Document contained an element with Attribute {$key=$value}"
+      )
+  }
+
+  class ContainElementWithTagMatcher(tag: String) extends Matcher[Element] {
+    override def apply(left: Element): MatchResult =
+      MatchResult(
+        left != null && !left.getElementsByTag(tag).isEmpty,
+        s"Document did not contain element with Tag {$tag}\n${actualContentWas(left)}",
+        s"Document contained an element with Tag {$tag}"
+      )
+  }
+
+  class ElementHasClassMatcher(clazz: String) extends Matcher[Element] {
+    override def apply(left: Element): MatchResult =
+      MatchResult(
+        left != null && left.classNames().contains(clazz),
+        s"Element did not have class {$clazz}\n${actualContentWas(left)}",
+        s"Element had class {$clazz}"
+      )
+  }
+
+  class ElementContainsTextMatcher(content: String) extends Matcher[Element] {
+    override def apply(left: Element): MatchResult =
+      MatchResult(
+        left != null && left.text().contains(content),
+        s"Element did not contain {$content}\n${actualContentWas(left)}",
+        s"Element contained {$content}"
+      )
+  }
+
+  class ElementContainsMessageMatcher(key: String, args: Seq[Any])(implicit messages: Messages) extends Matcher[Element] {
+    override def apply(left: Element): MatchResult = {
+      val message = messages(key, args: _*)
+      MatchResult(
+        left != null && left.text().contains(message),
+        s"Element did not contain message {$message}\n${actualContentWas(left)}",
+        s"Element contained message {$message}"
+      )
+    }
+  }
+
+  class ElementsContainsMessageMatcher(key: String, args: Seq[Any])(implicit messages: Messages) extends Matcher[Elements] {
+    override def apply(left: Elements): MatchResult = {
+      val message = messages(key, args: _*)
+      MatchResult(
+        left != null && left.text().contains(message),
+        s"Elements did not contain message {$message}\n${actualContentWas(left)}",
+        s"Elements contained message {$message}"
+      )
+    }
+  }
+
+  class ElementContainsHtmlMatcher(content: String) extends Matcher[Element] {
+    override def apply(left: Element): MatchResult =
+      MatchResult(
+        left != null && left.html().contains(content),
+        s"Element did not contain {$content}\n${actualContentWas(left)}",
+        s"Element contained {$content}"
+      )
+  }
+
+  class ElementContainsChildWithTextMatcher(tag: String, content: String) extends Matcher[Element] {
+    override def apply(left: Element): MatchResult = {
+
+      val matches = left != null && left.getElementsByTag(tag).exists(_.text().contains(content))
+      MatchResult(
+        matches,
+        s"Element did not contain text {$content}\n${actualContentWas(left.getElementsByTag(tag))}",
+        s"Element contained text {$content}"
+      )
+    }
+  }
+
+  class ElementContainsChildWithAttributeMatcher(tag: String, key: String, value: String) extends Matcher[Element] {
+    override def apply(left: Element): MatchResult =
+      MatchResult(
+        left != null && left.getElementsByTag(tag).exists(_.attr(key) == value),
+        s"Element attribute {$key} had value {${left.attr(key)}}, expected {$value}",
+        s"Element attribute {$key} had value {$value}"
+      )
+  }
+
+  class ElementHasAttributeValueMatcher(key: String, value: String) extends Matcher[Element] {
+    override def apply(left: Element): MatchResult =
+      MatchResult(
+        left != null && left.attr(key) == value,
+        s"Element attribute {$key} had value {${left.attr(key)}}, expected {$value}",
+        s"Element attribute {$key} had value {$value}"
+      )
+  }
+
+  class ElementHasAttributeMatcher(key: String) extends Matcher[Element] {
+    override def apply(left: Element): MatchResult =
+      MatchResult(left != null && left.hasAttr(key), s"Element didnt have attribute {$key}", s"Element had attribute {$key}")
+  }
+
+  class ElementHasChildCountMatcher(count: Int) extends Matcher[Element] {
+    override def apply(left: Element): MatchResult =
+      MatchResult(
+        left != null && left.children().size() == count,
+        s"Element had child count {${left.children().size()}}, expected {$count}",
+        s"Element had child count {$count}"
+      )
+  }
+
+  class ElementsHasSizeMatcher(size: Int) extends Matcher[Elements] {
+    override def apply(left: Elements): MatchResult =
+      MatchResult(left != null && left.size() == size, s"Elements had size {${left.size()}}, expected {$size}", s"Elements had size {$size}")
+  }
+
+  class ElementTagMatcher(tag: String) extends Matcher[Element] {
+    override def apply(left: Element): MatchResult =
+      MatchResult(left != null && left.tagName() == tag, s"Elements had tag {${left.tagName()}}, expected {$tag}", s"Elements had tag {$tag}")
+  }
+
+  class ElementContainsFieldError(fieldName: String, content: String = "") extends Matcher[Element] {
+    override def apply(left: Element): MatchResult = {
+      val element = left.getElementById(s"error-message-$fieldName-input")
+      val fieldErrorElement = if (element == null) left else element
+      MatchResult(
+        fieldErrorElement.text().contains(content),
+        s"Element did not contain {$content}\n${actualContentWas(fieldErrorElement)}",
+        s"Element contained {$content}"
+      )
+    }
+  }
+
+  class ElementContainsGovukFieldError(fieldName: String, content: String = "") extends Matcher[Element] {
+    override def apply(left: Element): MatchResult = {
+      val element = left.getElementById(s"$fieldName-error")
+      val fieldErrorElement = if (element == null) left else element
+      MatchResult(
+        fieldErrorElement.text().contains(content),
+        s"Element did not contain {$content}\n${actualContentWas(fieldErrorElement)}",
+        s"Element contained {$content}"
+      )
+    }
+  }
+
+  class ElementContainsFieldErrorLink(fieldName: String, link: String) extends Matcher[Element] {
+    override def apply(left: Element): MatchResult = {
+      val element = left.getElementById(s"$fieldName-error")
+      MatchResult(element != null && element.attr("href") == link, s"View not contains $fieldName with $link", s"View contains $fieldName with $link")
+    }
+  }
+
+  class ElementsHasElementsContainingTextMatcher(elementsClass: String, value: String) extends Matcher[Elements] {
+    override def apply(left: Elements): MatchResult =
+      MatchResult(
+        left != null && left.first().getElementsByClass(elementsClass).text() == value,
+        s"Elements with class {$elementsClass} had text {${left.first().getElementsByClass(elementsClass).text()}}, expected {$value}",
+        s"Element with class {$elementsClass} had text {${left.first().getElementsByClass(elementsClass).text()}}"
+      )
+  }
+
+  class ElementsHasSummaryActionMatcher(value: Call) extends Matcher[Elements] {
+    override def apply(left: Elements): MatchResult = {
+      val actionElement = Try(left.first().getElementsByClass("govuk-link").first()).toOption.orNull
+
+      MatchResult(
+        left != null && actionElement != null && actionElement.attr("href") == value.url,
+        s"Elements had no summary action {$value}\n${actualContentWas(actionElement)}",
+        s"Element had summary action {$value}"
+      )
+    }
+  }
+
+  class ChildMatcherBuilder(tag: String) {
+    def containingText(text: String) = new ElementContainsChildWithTextMatcher(tag, text)
+    def withAttribute(key: String, value: String) = new ElementContainsChildWithAttributeMatcher(tag, key, value)
+    def withName(value: String) = new ElementContainsChildWithAttributeMatcher(tag, "name", value)
+  }
+
+  class FormSubmitTo(path: String) extends Matcher[Element] {
+    override def apply(left: Element): MatchResult = {
+      val action = left.attr("action")
+      val formaction = left.attr("formaction")
+      MatchResult(action == path || formaction == path, s"Element ${left} does not submit to {$path}", s"Element ${left} does submit to {$path}")
+    }
+  }
+}


### PR DESCRIPTION
Phase Banner is implemented differently to other repositories,
due to this service not being moved to `govuk` design system.
As much as I would like to have all Exports UI services aligned,
this change would involve too much time to be performed 'by 
the way'.