### PR TITLE
CEDS-2746 Fix contact-frontend url

### DIFF
--- a/app/config/AppConfig.scala
+++ b/app/config/AppConfig.scala
@@ -76,11 +76,8 @@ case class Keystore(protocol: String = "https", host: String, port: Int, default
   lazy val baseUri: String = s"$protocol://$host:$port"
 }
 
-case class ContactFrontend(protocol: String = "https", host: String, port: Option[Int], serviceId: String) {
-  lazy val giveFeedbackLink: String = {
-    val contactFrontendBaseUrl = s"$protocol://$host:${port.getOrElse(443)}"
-    s"$contactFrontendBaseUrl/contact/beta-feedback-unauthenticated?service=$serviceId"
-  }
+case class ContactFrontend(url: String, serviceId: String) {
+  lazy val giveFeedbackLink: String = s"$url?service=$serviceId"
 }
 
 case class FileFormats(maxFileSizeMb: Int, approvedFileTypes: String, approvedFileExtensions: String)

--- a/app/config/AppConfig.scala
+++ b/app/config/AppConfig.scala
@@ -31,7 +31,8 @@ case class AppConfig(
   proxy: Proxy,
   accessibilityLinkUrl: String,
   answersRepository: AnswersRepository,
-  trackingConsentFrontend: TrackingConsentFrontend
+  trackingConsentFrontend: TrackingConsentFrontend,
+  platform: Platform
 )
 
 object AppConfig {
@@ -93,3 +94,7 @@ case class AnswersRepository(ttlSeconds: Int)
 case class Gtm(container: String)
 
 case class TrackingConsentFrontend(gtm: Gtm, url: String)
+
+case class Platform(frontend: Frontend)
+
+case class Frontend(host: Option[String])

--- a/app/views/components/phase_banner.scala.html
+++ b/app/views/components/phase_banner.scala.html
@@ -20,7 +20,8 @@
 
 @(phase: String)(implicit request: Request[_], messages: Messages)
 
-@betaFeedbackUrl = @{s"${appConfig.microservice.services.contactFrontend.giveFeedbackLink}&backURL=${request.uri}"}
+@backUrl = @{ appConfig.platform.frontend.host.map(url => s"&backUrl=$url${request.uri}").getOrElse("") }
+@betaFeedbackUrl = @{s"${appConfig.microservice.services.contactFrontend.giveFeedbackLink}$backUrl"}
 @link = {<a href="@betaFeedbackUrl">@messages("common.feedback.link")</a>}
 
 @feedbackBanner = {

--- a/app/views/components/phase_banner.scala.html
+++ b/app/views/components/phase_banner.scala.html
@@ -20,9 +20,7 @@
 
 @(phase: String)(implicit request: Request[_], messages: Messages)
 
-@protocol = @{ if(request.secure) "https" else "http" }
-@betaFeedbackUrl = @{s"${appConfig.microservice.services.contactFrontend.giveFeedbackLink}&backUrl=$protocol://${request.host}${request.uri}"}
-
+@betaFeedbackUrl = @{s"${appConfig.microservice.services.contactFrontend.giveFeedbackLink}&backURL=${request.uri}"}
 @link = {<a href="@betaFeedbackUrl">@messages("common.feedback.link")</a>}
 
 @feedbackBanner = {

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -120,9 +120,7 @@ microservice {
       }
 
       contact-frontend {
-        protocol = http
-        host = localhost
-        port = 9250
+        url = "http://localhost:9250/contact/beta-feedback-unauthenticated"
         service-id = "SFUS"
       }
     }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -217,3 +217,6 @@ tracking-consent-frontend {
   gtm.container = "a"
   url = "http://localhost:12345/tracking-consent/tracking.js"
 }
+
+# Default value for local environment
+platform.frontend.host = "http://localhost:6793"

--- a/run-contact-frontend-sm_local.sh
+++ b/run-contact-frontend-sm_local.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+sm --stop CONTACT_FRONTEND
+sm --start CONTACT --appendArgs '{"CONTACT_FRONTEND":["-DbackUrlDestinationWhitelist=http://localhost:6791,http://localhost:6793,http://localhost:6796"]}'

--- a/test/views/components/PhaseBannerSpec.scala
+++ b/test/views/components/PhaseBannerSpec.scala
@@ -17,7 +17,6 @@
 package views.components
 
 import base.{Injector, UnitViewSpec}
-import config.AppConfig
 import play.api.test.FakeRequest
 import play.twirl.api.Html
 import views.html.components.phase_banner
@@ -35,8 +34,7 @@ class PhaseBannerSpec extends UnitViewSpec with Injector {
 
     "display feedback link with correct href" in {
 
-      val appConfig = instanceOf[AppConfig]
-      val expectedHrefValue = s"${appConfig.microservice.services.contactFrontend.giveFeedbackLink}&backURL=$requestPath"
+      val expectedHrefValue = s"http://localhost:9250/contact/beta-feedback-unauthenticated?service=SFUS&backUrl=http://localhost:6793$requestPath"
 
       createBanner().getElementsByClass("phase-banner").first().getElementsByTag("a").first() must haveHref(expectedHrefValue)
     }

--- a/test/views/components/PhaseBannerSpec.scala
+++ b/test/views/components/PhaseBannerSpec.scala
@@ -36,7 +36,7 @@ class PhaseBannerSpec extends UnitViewSpec with Injector {
     "display feedback link with correct href" in {
 
       val appConfig = instanceOf[AppConfig]
-      val expectedHrefValue = s"${appConfig.microservice.services.contactFrontend.giveFeedbackLink}&backUrl=http://localhost$requestPath"
+      val expectedHrefValue = s"${appConfig.microservice.services.contactFrontend.giveFeedbackLink}&backURL=$requestPath"
 
       createBanner().getElementsByClass("phase-banner").first().getElementsByTag("a").first() must haveHref(expectedHrefValue)
     }


### PR DESCRIPTION
There are 2 issues that are fixed in this PR:
1. `backURL` should have capitalized 'URL'
2. In other environments, the link to `contact-frontend` was incorrect.
    It should be using url, similarly to how we link to Movements in
    Declarations service.