### PR TITLE
CEDS-2897 remove deprecated config

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -183,9 +183,6 @@ file-formats {
   approved-file-types = "image/jpeg,image/png,application/pdf,application/msword, application/vnd.openxmlformats-officedocument.wordprocessingml.document,application/vnd.ms-excel,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
 }
 
-ws.timeout.request: 300000
-ws.timeout.connection: 300000
-
 # ttl cannot be changed after initial deployment without manually dropping the index
 notifications {
   max-retries = 1000


### PR DESCRIPTION
ws.timeout.request and ws.timeout.connection are already being overridden with a default value by the bootstrap library. 

They would also be overridden by app-config-common since we don't have this configured in the environment configs, so it's my understanding we haven't had these values applied to the service for a while now. 

see [blogpost](https://confluence.tools.tax.service.gov.uk/display/TEC/2020/12/01/Cleanup+deprecated+Play+framework+configuration+keys)