### PR TITLE
CEDS-2762 Change content for Upload Error page

### DIFF
--- a/app/views/components/button_link.scala.html
+++ b/app/views/components/button_link.scala.html
@@ -1,0 +1,21 @@
+@*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@(messageKey: String = "", href: String, id: String = "link")(implicit messages: Messages)
+
+<div class="section">
+    <a href="@href" role="button" class="button" id="@id">@messages(messageKey)</a>
+</div>

--- a/app/views/upload_error.scala.html
+++ b/app/views/upload_error.scala.html
@@ -20,8 +20,24 @@
 
 @mainTemplate(title = messages("uploadError.title")) {
 
-    <h1 class="heading-xlarge">@messages("uploadError.heading")</h1>
+  <h1 class="heading-xlarge">@messages("uploadError.heading")</h1>
 
-    <p>@messages("uploadError.guidance")</p>
+  <p>@messages("uploadError.paragraph")</p>
+
+  <nav>
+    <ul class="list list-bullet">
+      <li>@messages("uploadError.bullet.1")</li>
+      <li>@messages("uploadError.bullet.2")</li>
+      <li>@messages("uploadError.bullet.3")</li>
+    </ul>
+  </nav>
+
+  @components.button_link(
+    messageKey = "uploadError.button",
+    href = controllers.routes.StartController.displayStartPage().url,
+    id = "startAgainButton"
+  )
+
+  <p>@messages("uploadError.guidance")</p>
 
 }

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -25,7 +25,7 @@ GET         /upload/receipt                     controllers.UploadYourFilesRecei
 
 GET         /upload/:ref                        controllers.UpscanStatusController.onPageLoad(ref: String)
 
-GET         /upload/upscan-error/            controllers.UpscanStatusController.error()
+GET         /upload/upscan-error/               controllers.UpscanStatusController.error()
 GET         /upload/upscan-success/:id          controllers.UpscanStatusController.success(id: String)
 
-GET         /help/accessibility                  controllers.StaticPagesController.accessibility
+GET         /help/accessibility                 controllers.StaticPagesController.accessibility

--- a/conf/messages
+++ b/conf/messages
@@ -112,9 +112,14 @@ unauthorised.applied.heading = If you’ve already applied to get access to CDS
 unauthorised.applied.paragraph1 = You can {0}
 unauthorised.applied.paragraph1.link = check the status of your application (opens in a new window or tab)
 
-uploadError.title=An error occurred during upload
-uploadError.heading=An error occurred during upload
-uploadError.guidance=An error has prevented your documents from being accepted. Please follow the guidance on gov.uk and submit your documents by an alternative method.
+uploadError.title=One of your files has been rejected
+uploadError.heading=One of your files has been rejected
+uploadError.paragraph=At least one of your files may be:
+uploadError.bullet.1=larger than 10MB
+uploadError.bullet.2=not an accepted file type
+uploadError.bullet.3=corrupted, or contain a virus
+uploadError.button=Start your upload again
+uploadError.guidance=You may be asked to check or re-enter the contact details.
 
 cds.error.title=Sorry, there is a problem with the service
 cds.error.heading=Sorry, there is a problem with the service

--- a/test/views/UploadErrorSpec.scala
+++ b/test/views/UploadErrorSpec.scala
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views
+
+import org.jsoup.nodes.Document
+import views.html.upload_error
+import utils.FakeRequestCSRFSupport._
+import views.behaviours.ViewBehaviours
+import views.matchers.ViewMatchers
+
+class UploadErrorSpec extends ViewBehaviours with ViewMatchers {
+
+  val page = instanceOf[upload_error]
+
+  val view = () => page()(fakeRequest.withCSRFToken, messages)
+
+  val messageKeyPrefix = "uploadError"
+
+  "Upload Error page" should {
+
+    behave like normalPage(view, messageKeyPrefix)
+
+    "have a paragraph" in {
+      val paragraph = asDocument(view()).getElementsByTag("p").get(2)
+
+      paragraph must containMessage("uploadError.paragraph")
+    }
+
+    "have a bullet list" in {
+      val bulletList = asDocument(view()).getElementsByClass("list list-bullet").first()
+
+      bulletList must containMessage("uploadError.bullet.1")
+      bulletList must containMessage("uploadError.bullet.2")
+      bulletList must containMessage("uploadError.bullet.3")
+    }
+
+    "have a button that links to start page" in {
+      val button = asDocument(view()).getElementById("startAgainButton")
+
+      button must containMessage("uploadError.button")
+      button must haveHref(controllers.routes.StartController.displayStartPage())
+    }
+
+    "have a guidance" in {
+      val guidance = asDocument(view()).getElementsByTag("p").get(3)
+
+      guidance must containMessage("uploadError.guidance")
+    }
+  }
+
+}


### PR DESCRIPTION
The previous content was not making it clear to the user on what might
have gone wrong, or what should they try to do next.
The new page contains a button that takes the user to the start page of
the service.