### PR TITLE
CEDS-2937 Remove first paragraph from Start page

### DIFF
--- a/app/views/start.scala.html
+++ b/app/views/start.scala.html
@@ -24,12 +24,6 @@
 
 <div class="form-group">
     <h1 class="heading-xlarge">@messages("startPage.heading")</h1>
-    <p>@messages("startPage.p.youWillNeed")</p>
-    <ul class="list-bullet form-group">
-        <li>@messages("startPage.listItem1")</li>
-        <li>@messages("startPage.listItem2")</li>
-        <li>@messages("startPage.listItem3")</li>
-    </ul>
 
     <p>@messages("startPage.paragraph2")</p>
     <p>@Html(messages("startPage.paragraph3", bold(messages("startPage.paragraph3.bold"))))</p>

--- a/test/views/StartSpec.scala
+++ b/test/views/StartSpec.scala
@@ -30,7 +30,7 @@ class StartSpec extends DomAssertions with ViewBehaviours {
   val messageKeyPrefix = "startPage"
 
   "Start Page" must {
-    behave like normalPage(view, messageKeyPrefix, "paragraph2", "p.youWillNeed", "listItem1", "listItem2", "listItem3")
+    behave like normalPage(view, messageKeyPrefix, "paragraph2")
     "have a start button with correct link" in {
       val doc = asDocument(view())
       val expectedLink = routes.StartController.onStart().url


### PR DESCRIPTION
This is a repetition of the GovUK page.
As per Liz's suggestion.