### PR TITLE
[CEDS-2978]_Implement_verified_email_check

### DIFF
--- a/app/Module.scala
+++ b/app/Module.scala
@@ -33,6 +33,7 @@ class Module extends AbstractModule {
     // Bind the actions for DI
     bind(classOf[AuthAction]).to(classOf[AuthActionImpl]).asEagerSingleton()
     bind(classOf[EORIRequiredAction]).to(classOf[EORIRequiredActionImpl]).asEagerSingleton()
+    bind(classOf[VerifiedEmailAction]).to(classOf[VerifiedEmailActionImpl]).asEagerSingleton()
     bind(classOf[ContactDetailsRequiredAction]).to(classOf[ContactDetailsRequiredActionImpl]).asEagerSingleton()
     bind(classOf[MrnRequiredAction]).to(classOf[MrnRequiredActionImpl]).asEagerSingleton()
     bind(classOf[DataRetrievalAction]).to(classOf[DataRetrievalActionImpl]).asEagerSingleton()

--- a/app/config/AppConfig.scala
+++ b/app/config/AppConfig.scala
@@ -57,7 +57,8 @@ case class Services(
   cdsFileUploadFrontend: CDSFileUploadFrontend,
   cdsFileUpload: CDSFileUpload,
   keystore: Keystore,
-  contactFrontend: ContactFrontend
+  contactFrontend: ContactFrontend,
+  customsEmailFrontend: CustomsEmailFrontend
 )
 
 case class CustomsDeclarations(protocol: Option[String], host: String, port: Option[Int], batchUploadUri: String, apiVersion: String) {
@@ -68,12 +69,22 @@ case class CDSFileUploadFrontend(protocol: Option[String], host: String, port: O
   val uri: String = s"${protocol.getOrElse("https")}://$host:${port.getOrElse(443)}"
 }
 
-case class CDSFileUpload(protocol: Option[String], host: String, port: Option[Int], fetchNotificationUri: String, fetchDeclarationStatus: String) {
+case class CDSFileUpload(
+  protocol: Option[String],
+  host: String,
+  port: Option[Int],
+  fetchNotificationUri: String,
+  fetchDeclarationStatus: String,
+  fetchVerifiedEmail: String
+) {
   def fetchNotificationEndpoint(reference: String): String =
     s"${protocol.getOrElse("https")}://$host:${port.getOrElse(443)}$fetchNotificationUri/$reference"
 
   def fetchDeclarationStatusEndpoint(mrn: String): String =
     s"${protocol.getOrElse("https")}://$host:${port.getOrElse(443)}$fetchDeclarationStatus/$mrn"
+
+  def fetchVerifiedEmailEndpoint(eori: String): String =
+    s"${protocol.getOrElse("https")}://$host:${port.getOrElse(443)}$fetchVerifiedEmail/$eori"
 }
 
 case class Keystore(protocol: String = "https", host: String, port: Int, defaultSource: String, domain: String) {
@@ -82,6 +93,10 @@ case class Keystore(protocol: String = "https", host: String, port: Int, default
 
 case class ContactFrontend(url: String, serviceId: String) {
   lazy val giveFeedbackLink: String = s"$url?service=$serviceId"
+}
+
+case class CustomsEmailFrontend(protocol: String = "https", host: String, port: Int) {
+  lazy val getRedirectionLink: String = s"$protocol://$host:$port/manage-email-cds/service/cds-file-upload"
 }
 
 case class FileFormats(maxFileSizeMb: Int, approvedFileTypes: String, approvedFileExtensions: String)

--- a/app/connectors/CdsFileUploadConnector.scala
+++ b/app/connectors/CdsFileUploadConnector.scala
@@ -17,12 +17,12 @@
 package connectors
 
 import config.{AppConfig, CDSFileUpload}
-import javax.inject.Inject
-import models.{MRN, Notification}
+import models.{EORI, MRN, Notification, VerifiedEmailAddress}
 import play.api.Logger
-import uk.gov.hmrc.http.HttpReads.Implicits._
 import uk.gov.hmrc.http.{HeaderCarrier, HttpClient, HttpResponse}
+import uk.gov.hmrc.http.HttpReads.Implicits._
 
+import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 
 class CdsFileUploadConnector @Inject()(appConfig: AppConfig, httpClient: HttpClient)(implicit ec: ExecutionContext) {
@@ -47,4 +47,16 @@ class CdsFileUploadConnector @Inject()(appConfig: AppConfig, httpClient: HttpCli
   def getDeclarationStatus(mrn: MRN)(implicit hc: HeaderCarrier): Future[HttpResponse] =
     httpClient.GET[HttpResponse](cdsFileUploadConfig.fetchDeclarationStatusEndpoint(mrn.value))
 
+  def getVerifiedEmailAddress(eori: EORI)(implicit hc: HeaderCarrier): Future[Option[VerifiedEmailAddress]] =
+    httpClient
+      .GET[Option[VerifiedEmailAddress]](cdsFileUploadConfig.fetchVerifiedEmailEndpoint(eori.value))
+      .map { maybeVerifiedEmail =>
+        maybeVerifiedEmail match {
+          case Some(verifiedEmailAddress) =>
+            logger.debug(s"Found verified email for eori: $eori")
+          case None =>
+            logger.info(s"No verified email for eori: $eori")
+        }
+        maybeVerifiedEmail
+      }
 }

--- a/app/controllers/MrnEntryController.scala
+++ b/app/controllers/MrnEntryController.scala
@@ -19,7 +19,6 @@ package controllers
 import com.google.inject.Singleton
 import controllers.actions._
 import forms.MRNFormProvider
-import javax.inject.Inject
 import models.EORI
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
@@ -27,6 +26,7 @@ import services.{AnswersService, MrnDisValidator}
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import views.html.{mrn_access_denied, mrn_entry}
 
+import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
@@ -34,6 +34,7 @@ class MrnEntryController @Inject()(
   authenticate: AuthAction,
   requireEori: EORIRequiredAction,
   getData: DataRetrievalAction,
+  verifiedEmail: VerifiedEmailAction,
   formProvider: MRNFormProvider,
   answersConnector: AnswersService,
   mcc: MessagesControllerComponents,
@@ -45,12 +46,12 @@ class MrnEntryController @Inject()(
 
   val form = formProvider()
 
-  def onPageLoad: Action[AnyContent] = (authenticate andThen requireEori andThen getData) { implicit req =>
+  def onPageLoad: Action[AnyContent] = (authenticate andThen requireEori andThen verifiedEmail andThen getData) { implicit req =>
     val populatedForm = req.userAnswers.mrn.fold(form)(form.fill)
     Ok(mrnEntry(populatedForm))
   }
 
-  def onSubmit: Action[AnyContent] = (authenticate andThen requireEori andThen getData).async { implicit req =>
+  def onSubmit: Action[AnyContent] = (authenticate andThen requireEori andThen verifiedEmail andThen getData).async { implicit req =>
     form
       .bindFromRequest()
       .fold(

--- a/app/controllers/UnverifiedEmailController.scala
+++ b/app/controllers/UnverifiedEmailController.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+
+import config.AppConfig
+import controllers.actions.{AuthAction, EORIRequiredAction}
+import play.api.i18n.I18nSupport
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
+import views.html.unverified_email
+
+import javax.inject.{Inject, Singleton}
+
+@Singleton
+class UnverifiedEmailController @Inject()(
+  authenticate: AuthAction,
+  requireEori: EORIRequiredAction,
+  mcc: MessagesControllerComponents,
+  unverified_email: unverified_email,
+  appConfig: AppConfig
+) extends FrontendController(mcc) with I18nSupport {
+
+  val informUser: Action[AnyContent] = (authenticate andThen requireEori) { implicit req =>
+    val redirectUrl = appConfig.microservice.services.customsEmailFrontend.getRedirectionLink
+    Ok(unverified_email(redirectUrl))
+  }
+}

--- a/app/controllers/UploadYourFilesReceiptController.scala
+++ b/app/controllers/UploadYourFilesReceiptController.scala
@@ -36,6 +36,7 @@ import scala.concurrent.{ExecutionContext, Future}
 class UploadYourFilesReceiptController @Inject()(
   authenticate: AuthAction,
   requireEori: EORIRequiredAction,
+  verifiedEmail: VerifiedEmailAction,
   cdsFileUploadConnector: CdsFileUploadConnector,
   metrics: SfusMetrics,
   uploadYourFilesReceipt: upload_your_files_receipt,
@@ -43,7 +44,7 @@ class UploadYourFilesReceiptController @Inject()(
 )(implicit mcc: MessagesControllerComponents, ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport {
 
-  def onPageLoad(): Action[AnyContent] = (authenticate andThen requireEori).async { implicit req =>
+  def onPageLoad(): Action[AnyContent] = (authenticate andThen requireEori andThen verifiedEmail).async { implicit req =>
     answersConnector.findByEori(req.eori).flatMap { maybeUserAnswers =>
       val result = for {
         userAnswers <- getOrRedirect(maybeUserAnswers, routes.StartController.displayStartPage())

--- a/app/controllers/actions/ContactDetailsRequiredAction.scala
+++ b/app/controllers/actions/ContactDetailsRequiredAction.scala
@@ -27,7 +27,7 @@ import scala.concurrent.{ExecutionContext, Future}
 class ContactDetailsRequiredActionImpl @Inject()(val mcc: MessagesControllerComponents) extends ContactDetailsRequiredAction {
 
   implicit val executionContext: ExecutionContext = mcc.executionContext
-  private val onError = Redirect(routes.ErrorPageController.error())
+  private lazy val onError = Redirect(routes.ErrorPageController.error())
 
   override protected def refine[A](request: MrnRequest[A]): Future[Either[Result, ContactDetailsRequest[A]]] = {
     val req = for {

--- a/app/controllers/actions/DataRetrievalAction.scala
+++ b/app/controllers/actions/DataRetrievalAction.scala
@@ -16,19 +16,19 @@
 
 package controllers.actions
 
-import javax.inject.Inject
-import models.requests.{DataRequest, EORIRequest}
+import models.requests.{DataRequest, VerifiedEmailRequest}
 import play.api.mvc.{ActionTransformer, MessagesControllerComponents}
 import services.AnswersService
 
+import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 
 class DataRetrievalActionImpl @Inject()(val answersConnector: AnswersService, mcc: MessagesControllerComponents) extends DataRetrievalAction {
 
   implicit val executionContext: ExecutionContext = mcc.executionContext
 
-  override protected def transform[A](request: EORIRequest[A]): Future[DataRequest[A]] =
+  override protected def transform[A](request: VerifiedEmailRequest[A]): Future[DataRequest[A]] =
     answersConnector.findOrCreate(request.eori).map(DataRequest(request, _))
 }
 
-trait DataRetrievalAction extends ActionTransformer[EORIRequest, DataRequest]
+trait DataRetrievalAction extends ActionTransformer[VerifiedEmailRequest, DataRequest]

--- a/app/controllers/actions/EORIRequiredAction.scala
+++ b/app/controllers/actions/EORIRequiredAction.scala
@@ -28,7 +28,7 @@ import scala.concurrent.{ExecutionContext, Future}
 class EORIRequiredActionImpl @Inject()(mcc: MessagesControllerComponents) extends EORIRequiredAction {
 
   implicit val executionContext: ExecutionContext = mcc.executionContext
-  private val onError = Redirect(routes.UnauthorisedController.onPageLoad())
+  private lazy val onError = Redirect(routes.UnauthorisedController.onPageLoad())
 
   override protected def refine[A](request: AuthenticatedRequest[A]): Future[Either[Result, EORIRequest[A]]] = {
     val req = for {

--- a/app/controllers/actions/FileUploadResponseRequiredAction.scala
+++ b/app/controllers/actions/FileUploadResponseRequiredAction.scala
@@ -28,7 +28,7 @@ class FileUploadResponseRequiredAction @Inject()(implicit mcc: MessagesControlle
     extends ActionRefiner[DataRequest, FileUploadResponseRequest] {
 
   implicit override val executionContext: ExecutionContext = mcc.executionContext
-  private val onError = Redirect(routes.ErrorPageController.error())
+  private lazy val onError = Redirect(routes.ErrorPageController.error())
 
   override protected def refine[A](request: DataRequest[A]): Future[Either[Result, FileUploadResponseRequest[A]]] = {
 

--- a/app/controllers/actions/MrnRequiredAction.scala
+++ b/app/controllers/actions/MrnRequiredAction.scala
@@ -28,10 +28,10 @@ import scala.concurrent.{ExecutionContext, Future}
 class MrnRequiredActionImpl @Inject()(mcc: MessagesControllerComponents) extends MrnRequiredAction {
 
   implicit val executionContext: ExecutionContext = mcc.executionContext
-  private val onError = Redirect(routes.ErrorPageController.error())
+  private lazy val onError = Redirect(routes.ErrorPageController.error())
 
   override protected def refine[A](request: DataRequest[A]): Future[Either[Result, MrnRequest[A]]] =
-    Future.successful(request.userAnswers.mrn.map(mrn => MrnRequest(request.request, request.userAnswers, mrn)).toRight(onError))
+    Future.successful(request.userAnswers.mrn.map(mrn => MrnRequest(request.request.request, request.userAnswers, mrn)).toRight(onError))
 }
 
 trait MrnRequiredAction extends ActionRefiner[DataRequest, MrnRequest]

--- a/app/controllers/actions/VerifiedEmailAction.scala
+++ b/app/controllers/actions/VerifiedEmailAction.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.actions
+
+import connectors.CdsFileUploadConnector
+import controllers.routes
+import models.requests.{EORIRequest, VerifiedEmailRequest}
+import models.EORI
+import play.api.mvc.{ActionRefiner, MessagesControllerComponents, Result}
+import play.api.mvc.Results.Redirect
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.play.HeaderCarrierConverter
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
+
+trait VerifiedEmailAction extends ActionRefiner[EORIRequest, VerifiedEmailRequest]
+
+@Singleton
+class VerifiedEmailActionImpl @Inject()(backendConnector: CdsFileUploadConnector, mcc: MessagesControllerComponents) extends VerifiedEmailAction {
+
+  implicit val executionContext: ExecutionContext = mcc.executionContext
+  private lazy val onError = Redirect(routes.UnverifiedEmailController.informUser)
+
+  override protected def refine[A](request: EORIRequest[A]): Future[Either[Result, VerifiedEmailRequest[A]]] = {
+
+    implicit val hc: HeaderCarrier = HeaderCarrierConverter.fromHeadersAndSession(request.headers, Some(request.session))
+
+    backendConnector.getVerifiedEmailAddress(EORI(request.eori)).map { maybeVerifiedEmail =>
+      maybeVerifiedEmail
+        .map(verifiedEmail => VerifiedEmailRequest(request, verifiedEmail.address))
+        .toRight(onError)
+    }
+  }
+}

--- a/app/models/VerifiedEmailAddress.scala
+++ b/app/models/VerifiedEmailAddress.scala
@@ -1,4 +1,4 @@
-@*
+/*
  * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,21 +12,16 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *@
+ */
 
-@this(mainTemplate: main_template)
+package models
 
-@()(implicit request: Request[_], messages: Messages)
+import play.api.libs.json.{Json, OFormat}
 
-@mainTemplate(title = messages("cds.error.heading")) {
+import java.time.ZonedDateTime
 
-    <h1 class="heading-xlarge">@messages("cds.error.heading")</h1>
-    <p>@messages("cds.error.message")</p>
-    <div>
-        <h2 class="heading-medium">@messages("cds.error.helpSupport")</h2>
+case class VerifiedEmailAddress(address: String, timestamp: ZonedDateTime)
 
-        <div class="section">
-            <p>@messages("helpline.generic")</p>
-        </div>
-    </div>
+object VerifiedEmailAddress {
+  implicit val format: OFormat[VerifiedEmailAddress] = Json.format[VerifiedEmailAddress]
 }

--- a/app/models/requests/ContactDetailsRequest.scala
+++ b/app/models/requests/ContactDetailsRequest.scala
@@ -20,4 +20,6 @@ import models._
 import play.api.mvc.WrappedRequest
 
 case class ContactDetailsRequest[A](request: MrnRequest[A], userAnswers: UserAnswers, contactDetails: ContactDetails)
-    extends WrappedRequest[A](request) with Authenticated
+    extends WrappedRequest[A](request) with Authenticated {
+  val eori = request.eori
+}

--- a/app/models/requests/DataRequest.scala
+++ b/app/models/requests/DataRequest.scala
@@ -19,4 +19,4 @@ package models.requests
 import models._
 import play.api.mvc.WrappedRequest
 
-case class DataRequest[A](request: EORIRequest[A], userAnswers: UserAnswers) extends WrappedRequest[A](request) with Authenticated
+case class DataRequest[A](request: VerifiedEmailRequest[A], userAnswers: UserAnswers) extends WrappedRequest[A](request) with Authenticated

--- a/app/models/requests/FileUploadResponseRequest.scala
+++ b/app/models/requests/FileUploadResponseRequest.scala
@@ -19,5 +19,7 @@ package models.requests
 import models._
 import play.api.mvc.WrappedRequest
 
-case class FileUploadResponseRequest[A](request: EORIRequest[A], userAnswers: UserAnswers, fileUploadResponse: FileUploadResponse)
-    extends WrappedRequest[A](request) with Authenticated
+case class FileUploadResponseRequest[A](request: VerifiedEmailRequest[A], userAnswers: UserAnswers, fileUploadResponse: FileUploadResponse)
+    extends WrappedRequest[A](request) with Authenticated {
+  val eori = request.eori
+}

--- a/app/models/requests/VerifiedEmailRequest.scala
+++ b/app/models/requests/VerifiedEmailRequest.scala
@@ -1,4 +1,4 @@
-@*
+/*
  * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,21 +12,12 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *@
+ */
 
-@this(mainTemplate: main_template)
+package models.requests
 
-@()(implicit request: Request[_], messages: Messages)
+import play.api.mvc.WrappedRequest
 
-@mainTemplate(title = messages("cds.error.heading")) {
-
-    <h1 class="heading-xlarge">@messages("cds.error.heading")</h1>
-    <p>@messages("cds.error.message")</p>
-    <div>
-        <h2 class="heading-medium">@messages("cds.error.helpSupport")</h2>
-
-        <div class="section">
-            <p>@messages("helpline.generic")</p>
-        </div>
-    </div>
+case class VerifiedEmailRequest[A](request: EORIRequest[A], email: String) extends WrappedRequest[A](request) with Authenticated {
+  val eori = request.eori
 }

--- a/app/views/components/error_summary.scala.html
+++ b/app/views/components/error_summary.scala.html
@@ -19,7 +19,7 @@
 <div class="error-summary error-summary--show" role="group" aria-labelledby="error-summary-heading" tabindex="-1">
 
     <h2 class="heading-medium error-summary-heading" id="error-summary-heading">
-        @messages("error.summary.title")
+        @messages("error.summary.heading")
     </h2>
 
     <ul role="list" class="error-summary-list">

--- a/app/views/contact_details.scala.html
+++ b/app/views/contact_details.scala.html
@@ -20,7 +20,7 @@
 
 @(form: Form[ContactDetails])(implicit request: Request[_], messages: Messages)
 
-@mainTemplate(title = s"${errorPrefix(form)} ${messages("contactDetails.title")}") {
+@mainTemplate(title = s"${errorPrefix(form)} ${messages("contactDetails.heading")}") {
 
     <div class="form-group">
         <h1 class="heading-large">@messages("contactDetails.heading")</h1>

--- a/app/views/helpers/Utils.scala
+++ b/app/views/helpers/Utils.scala
@@ -23,7 +23,7 @@ import play.twirl.api.Html
 object Utils {
 
   def errorPrefix(form: Form[_])(implicit messages: Messages): String =
-    if (form.hasErrors || form.hasGlobalErrors) messages("error.browser.title.prefix") else ""
+    if (form.hasErrors || form.hasGlobalErrors) messages("error.browser.heading.prefix") else ""
 
   def multiline(values: String*): Html =
     Html(values.toList.mkString("<br />"))

--- a/app/views/how_many_files_upload.scala.html
+++ b/app/views/how_many_files_upload.scala.html
@@ -20,7 +20,7 @@
 
 @(form: Form[FileUploadCount])(implicit request: Request[_], messages: Messages)
 
-@mainTemplate(title = s"${errorPrefix(form)} ${messages("howManyFilesUpload.title")}") {
+@mainTemplate(title = s"${errorPrefix(form)} ${messages("howManyFilesUpload.heading")}") {
 
 <div class="form-group">
     @components.error_summary(form.errors)
@@ -31,7 +31,7 @@
 
         @components.input_text(
             form("value"),
-            messages("howManyFilesUpload.title"),
+            messages("howManyFilesUpload.heading"),
             labelClass = Some("visually-hidden")
         )
 

--- a/app/views/mrn_entry.scala.html
+++ b/app/views/mrn_entry.scala.html
@@ -20,7 +20,7 @@
 
 @(form: Form[MRN])(implicit request: Request[_], messages: Messages)
 
-@mainTemplate(title = s"${errorPrefix(form)} ${messages("mrnEntryPage.title")}") {
+@mainTemplate(title = s"${errorPrefix(form)} ${messages("mrnEntryPage.heading")}") {
 
 <div class="form-group">
     @components.error_summary(form.errors)

--- a/app/views/signed_out.scala.html
+++ b/app/views/signed_out.scala.html
@@ -31,7 +31,7 @@
 
 @startPageLink = {<a href="@routes.StartController.displayStartPage()">@messages("signedOut.startPageLink")</a>}
 
-@gdsMainTemplate(title = Title("signedOut.title")) {
+@gdsMainTemplate(title = Title("signedOut.heading")) {
 
     @pageTitle(messages("signedOut.heading"))
 

--- a/app/views/start.scala.html
+++ b/app/views/start.scala.html
@@ -20,7 +20,7 @@
 
 @()(implicit request: Request[_], messages: Messages)
 
-@mainTemplate(title = messages("startPage.title")) {
+@mainTemplate(title = messages("startPage.heading")) {
 
     <div class="form-group">
         <h1 class="heading-xlarge">@messages("startPage.heading")</h1>

--- a/app/views/unverified_email.scala.html
+++ b/app/views/unverified_email.scala.html
@@ -1,0 +1,50 @@
+@*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import models.MRN
+@import views.Title
+@import views.html.components.gds._
+@import views.html.components._
+
+
+@this(
+  mainTemplate: gdsMainTemplate,
+  pageTitle: pageTitle,
+  paragraphBody: paragraphBody,
+  linkButton: link_button,
+  link: link
+)
+
+@(redirectionUrl: String)(implicit request: Request[_], messages: Messages)
+
+@mainTemplate(title = Title("emailUnverified.heading")) {
+
+  @pageTitle(messages("emailUnverified.heading"))
+
+  @paragraphBody(message = messages("emailUnverified.paragraph1"), id = Some("emailUnverified.para1"))
+  <ul class="govuk-list govuk-list--bullet" id="emailUnverified.bullets">
+      <li>@messages("emailUnverified.bullets.item1")</li>
+      <li>@messages("emailUnverified.bullets.item2")</li>
+      <li>@messages("emailUnverified.bullets.item3")</li>
+      <li>@messages("emailUnverified.bullets.item4")</li>
+      <li>@messages("emailUnverified.bullets.item5")</li>
+  </ul>
+
+  @linkButton(
+    messageKey = "emailUnverified.link",
+    call = Call("GET", redirectionUrl)
+  )
+}

--- a/app/views/upload_error.scala.html
+++ b/app/views/upload_error.scala.html
@@ -23,7 +23,7 @@
 
 @()(implicit request: Request[_], messages: Messages)
 
-@mainTemplate(title = messages("uploadError.title")) {
+@mainTemplate(title = messages("uploadError.heading")) {
 
   <h1 class="heading-xlarge">@messages("uploadError.heading")</h1>
 

--- a/app/views/upload_your_files.scala.html
+++ b/app/views/upload_your_files.scala.html
@@ -30,7 +30,7 @@
     }
 }
 
-@mainTemplate(title = messages(s"fileUploadPage.title.$positionModifier")) {
+@mainTemplate(title = messages(s"fileUploadPage.heading.$positionModifier")) {
 
 
     <h1 class="heading-large">

--- a/app/views/upload_your_files_receipt.scala.html
+++ b/app/views/upload_your_files_receipt.scala.html
@@ -43,7 +43,7 @@
 
 @listItemWithLink = {@nchLink @messages("fileUploadReceiptPage.listitem5")}
 
-@govukLayout(title = Title("fileUploadReceiptPage.title")) {
+@govukLayout(title = Title("fileUploadReceiptPage.heading")) {
     @govukPanel(Panel(
         title = Text(messages("fileUploadReceiptPage.heading")),
         content = HtmlContent(panelContent)

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -26,6 +26,8 @@ GET         /upload/:ref                        controllers.UpscanStatusControll
 GET         /upload/upscan-error/               controllers.UpscanStatusController.error()
 GET         /upload/upscan-success/:id          controllers.UpscanStatusController.success(id: String)
 
+GET         /unverified-email                   controllers.UnverifiedEmailController.informUser
+
 # Sign out
 GET         /sign-out                           controllers.SignOutController.signOut
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -118,11 +118,18 @@ microservice {
         port = 6795
         fetch-notification-uri = /cds-file-upload/notification
         fetch-declaration-status = /cds-file-upload/declaration-information
+        fetch-verified-email = /cds-file-upload/eori-email
       }
 
       contact-frontend {
         url = "http://localhost:9250/contact/beta-feedback-unauthenticated"
         service-id = "SFUS"
+      }
+
+      customs-email-frontend {
+        protocol = http
+        host = localhost
+        port = 9898
       }
     }
 }

--- a/conf/messages
+++ b/conf/messages
@@ -7,15 +7,14 @@ common.feedback=This is a new service - your {0} will help us to improve it.
 common.feedback.link=feedback
 
 ## errors
-error.browser.title.prefix=Error:
-error.summary.title=There is a problem
+error.browser.heading.prefix=Error:
+error.summary.heading=There is a problem
 
 ## common buttons with shared labels
 common.button.startNow=Start now
 
 ## start page
 
-startPage.title=Upload a customs document
 startPage.heading=Upload a customs document
 startPage.paragraph2=You will need to know how many files you want to upload before you start uploading them. You can submit a maximum of 10 files, and each file can be up to 10 Megabytes (MB).
 startPage.paragraph3= {0} - if you have two photos of an invoice saved as separate jpegs, this is two files.
@@ -30,7 +29,6 @@ startPage.listItem3=the movement reference number (MRN) of your declaration
 ## Sign-out
 
 signOut.link = Sign out
-signedOut.title = You have been signed out
 signedOut.heading = You have been signed out
 signedOut.session.timeout.heading = For your security, we have signed you out
 signedOut.information = To use the service again, you will need to {0}.
@@ -39,7 +37,6 @@ signedOut.backToGovUk = Back to GOV.UK
 
 ## MRN Entry Page
 
-mrnEntryPage.title=What is your movement reference number (MRN)?
 mrnEntryPage.heading=What is your movement reference number (MRN)?
 mrnEntryPage.hint1=This is 18 digits long, and is made up of letters and numbers.
 mrnEntryPage.hint2=You were given this when you submitted your declaration.
@@ -52,9 +49,19 @@ mrnAccessDenied.paragraph.1=If the MRN is correct and current, this may mean the
 mrnAccessDenied.paragraph.2=The documents can also be uploaded by another person from the same business, using a Gateway ID that has been given access to the Customs Declaration Service by that business.
 mrnAccessDenied.link.enterDifferentMrn=Enter a different MRN
 
+## Unverified email waring page
+
+emailUnverified.heading=You need to verify your email address for the Customs Declaration Service
+emailUnverified.paragraph1=This will be the only email address we use for:
+emailUnverified.bullets.item1=urgent updates about goods in customs
+emailUnverified.bullets.item2=notifications about import and export declarations
+emailUnverified.bullets.item3=import VAT and duty deferment statements
+emailUnverified.bullets.item4=duty deferment Direct Debit notices
+emailUnverified.bullets.item5=updates about changes to the service
+emailUnverified.link=Verify your email address
+
 ## Contact details page
 
-contactDetails.title=Your contact details
 contactDetails.heading=Your contact details
 contactDetails.name=Name
 contactDetails.companyName=Company name
@@ -70,7 +77,6 @@ contactDetails.paragraph1=Provide these details so we can contact you if there a
 
 ## file warning page
 
-fileWarning.title=Count your files
 fileWarning.heading=Count your files
 fileWarning.paragraph1=HMRC need to know how many files you want to upload before you start uploading them.
 fileWarning.paragraph2=This is not the same as the number of documents.
@@ -79,13 +85,9 @@ fileWarning.button=I understand
 
 ## How many files do you need to upload page
 
-howManyFilesUpload.title=How many files do you need to upload?
 howManyFilesUpload.heading=How many files do you need to upload?
 howManyFilesUpload.invalid=You have entered an invalid number of files, you can upload 1 or more files up to a maximum number of 10 files. Re-enter the number of files you wish to upload.
 
-fileUploadPage.title.first=Upload your first file
-fileUploadPage.title.middle=Upload your next file
-fileUploadPage.title.last=Upload your last file
 fileUploadPage.heading.first=Upload your first file
 fileUploadPage.heading.middle=Upload your next file
 fileUploadPage.heading.last=Upload your last file
@@ -103,7 +105,6 @@ fileUploadPage.validation.filesize=The file you have chosen is bigger than {0}MB
 fileUploadPage.paragraph1=Ensure that you select the correct documents as requested by HMRC.
 fileUploadPage.button=Upload a document
 
-fileUploadReceiptPage.title=Uploaded files receipt
 fileUploadReceiptPage.heading=Files have been uploaded and sent to HMRC
 fileUploadReceiptPage.mrn=Movement Reference Number:
 fileUploadReceiptPage.tableTitle=Uploaded files
@@ -132,7 +133,6 @@ unauthorised.paragraph.2 = If you’ve already applied for an EORI number, you c
 unauthorised.paragraph.2.link = check the status of your application
 
 ## Errors
-uploadError.title=One of your files has been rejected
 uploadError.heading=One of your files has been rejected
 uploadError.paragraph=At least one of your files may be:
 uploadError.bullet.1=larger than 10MB
@@ -141,7 +141,6 @@ uploadError.bullet.3=corrupted, or contain a virus
 uploadError.button=Start your upload again
 uploadError.guidance=You may be asked to check or re-enter the contact details.
 
-cds.error.title=Sorry, there is a problem with the service
 cds.error.heading=Sorry, there is a problem with the service
 cds.error.message=Please try again later.
 cds.error.helpSupport=Help and support

--- a/test/base/AppConfigMockHelper.scala
+++ b/test/base/AppConfigMockHelper.scala
@@ -24,6 +24,7 @@ import config.{
   CDSFileUploadFrontend,
   ContactFrontend,
   CustomsDeclarations,
+  CustomsEmailFrontend,
   Feedback,
   FileFormats,
   GoogleAnalytics,
@@ -71,6 +72,7 @@ object AppConfigMockHelper extends MockitoSugar {
     cdsFileUploadFrontend: CDSFileUploadFrontend = mock[CDSFileUploadFrontend],
     cdsFileUpload: CDSFileUpload = mock[CDSFileUpload],
     keystore: Keystore = mock[Keystore],
-    contactFrontend: ContactFrontend = mock[ContactFrontend]
-  ) = Services(customsDeclarations, cdsFileUploadFrontend, cdsFileUpload, keystore, contactFrontend)
+    contactFrontend: ContactFrontend = mock[ContactFrontend],
+    customsEmailFrontend: CustomsEmailFrontend = mock[CustomsEmailFrontend]
+  ) = Services(customsDeclarations, cdsFileUploadFrontend, cdsFileUpload, keystore, contactFrontend, customsEmailFrontend)
 }

--- a/test/base/UnitViewSpec.scala
+++ b/test/base/UnitViewSpec.scala
@@ -38,7 +38,7 @@ class UnitViewSpec extends UnitSpec with ViewMatchers {
   val realMessagesApi = UnitViewSpec.realMessagesApi
 
   def checkErrorsSummary(view: Document): Assertion = {
-    view.getElementById("error-summary-heading").text() must be("error.summary.title")
+    view.getElementById("error-summary-heading").text() must be("error.summary.heading")
     view.getElementsByClass("error-summary error-summary--show").get(0).getElementsByTag("p").text() must be("error.summary.text")
   }
 }

--- a/test/config/AppConfigSpec.scala
+++ b/test/config/AppConfigSpec.scala
@@ -38,10 +38,9 @@ class AppConfigSpec extends PlaySpec {
     "have a correct configuration for CDS File Upload" in {
       val cdsFileUpload = config.microservice.services.cdsFileUpload
 
-      val fileReference = "reference"
-      val expectedUrl = "http://localhost:6795/cds-file-upload/notification/reference"
-
-      cdsFileUpload.fetchNotificationEndpoint(fileReference) mustBe expectedUrl
+      cdsFileUpload.fetchNotificationEndpoint("reference") mustBe "http://localhost:6795/cds-file-upload/notification/reference"
+      cdsFileUpload.fetchDeclarationStatusEndpoint("sampleMrn") mustBe "http://localhost:6795/cds-file-upload/declaration-information/sampleMrn"
+      cdsFileUpload.fetchVerifiedEmailEndpoint("sampleEori") mustBe "http://localhost:6795/cds-file-upload/eori-email/sampleEori"
     }
 
     "have gtm container" in {
@@ -61,6 +60,10 @@ class AppConfigSpec extends PlaySpec {
       val expectedUrl = "http://localhost:9250/contact/beta-feedback-unauthenticated?service=SFUS"
 
       config.microservice.services.contactFrontend.giveFeedbackLink mustBe expectedUrl
+    }
+
+    "have a correct configuration for Customs Email Frontend" in {
+      config.microservice.services.customsEmailFrontend.getRedirectionLink mustBe "http://localhost:9898/manage-email-cds/service/cds-file-upload"
     }
   }
 }

--- a/test/controllers/ContactDetailsControllerSpec.scala
+++ b/test/controllers/ContactDetailsControllerSpec.scala
@@ -44,6 +44,7 @@ class ContactDetailsControllerSpec extends ControllerSpecBase {
       new FakeEORIAction(eori),
       dataRetrieval,
       new FakeMrnRequiredAction,
+      new FakeVerifiedEmailAction(),
       mockAnswersConnector,
       mcc,
       page

--- a/test/controllers/HowManyFilesUploadControllerSpec.scala
+++ b/test/controllers/HowManyFilesUploadControllerSpec.scala
@@ -73,6 +73,7 @@ class HowManyFilesUploadControllerSpec extends ControllerSpecBase with DomAssert
       new FakeDataRetrievalAction(answers),
       new MrnRequiredActionImpl(mcc),
       contactDetailsRequiredAction,
+      new FakeVerifiedEmailAction(),
       new FileUploadCountProvider,
       mockAnswersConnector,
       mockUpscanConnector,

--- a/test/controllers/MrnEntryControllerSpec.scala
+++ b/test/controllers/MrnEntryControllerSpec.scala
@@ -41,6 +41,7 @@ class MrnEntryControllerSpec extends ControllerSpecBase {
       new FakeAuthAction(),
       new FakeEORIAction(eori),
       new FakeDataRetrievalAction(Some(answers)),
+      new FakeVerifiedEmailAction(),
       new MRNFormProvider,
       mockAnswersConnector,
       mcc,

--- a/test/controllers/UnverifiedEmailControllerSpec.scala
+++ b/test/controllers/UnverifiedEmailControllerSpec.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+
+import org.mockito.ArgumentMatchers._
+import org.mockito.Mockito.{reset, when}
+import play.api.test.Helpers._
+import play.twirl.api.HtmlFormat
+import views.html.unverified_email
+
+class UnverifiedEmailControllerSpec extends ControllerSpecBase {
+
+  val page = mock[unverified_email]
+
+  def view(): String = page("")(fakeRequest, messages).toString
+
+  def controller() =
+    new UnverifiedEmailController(new FakeAuthAction(), new FakeEORIAction(), mcc, page, appConfig)
+
+  override protected def beforeEach(): Unit = {
+    super.beforeEach
+
+    reset(page)
+    when(page.apply(any())(any(), any())).thenReturn(HtmlFormat.empty)
+  }
+
+  "UnverifiedEmailController" should {
+
+    "display the unverified email detection page" in {
+
+      val result = controller().informUser(fakeRequest)
+
+      status(result) mustBe OK
+    }
+  }
+}

--- a/test/controllers/UploadYourFilesReceiptControllerSpec.scala
+++ b/test/controllers/UploadYourFilesReceiptControllerSpec.scala
@@ -40,6 +40,7 @@ class UploadYourFilesReceiptControllerSpec extends ControllerSpecBase with SfusM
     new UploadYourFilesReceiptController(
       new FakeAuthAction(),
       new FakeEORIAction(eori),
+      new FakeVerifiedEmailAction(),
       cdsFileUploadConnector,
       sfusMetrics,
       page,

--- a/test/controllers/UpscanStatusControllerSpec.scala
+++ b/test/controllers/UpscanStatusControllerSpec.scala
@@ -43,21 +43,6 @@ class UpscanStatusControllerSpec extends ControllerSpecBase with SfusMetricsMock
   val cdsFileUploadConnector = mock[CdsFileUploadConnector]
   val eori: String = eoriString.sample.get
 
-  val controller = new UpscanStatusController(
-    new FakeAuthAction(),
-    new FakeEORIAction(eori),
-    fakeDataRetrievalAction(),
-    new FileUploadResponseRequiredAction(),
-    mockAnswersConnector,
-    auditConnector,
-    cdsFileUploadConnector,
-    appConfig,
-    mcc,
-    sfusMetrics,
-    uploadYourFiles,
-    uploadError
-  )(executionContext)
-
   private val mockAuditConnector = mock[AuditConnector]
 
   private val responseGen: Gen[(FileUpload, FileUploadResponse)] =
@@ -77,11 +62,12 @@ class UpscanStatusControllerSpec extends ControllerSpecBase with SfusMetricsMock
       }
   }
 
-  def controller(getData: DataRetrievalAction) =
+  def controller(getData: DataRetrievalAction = fakeDataRetrievalAction()) =
     new UpscanStatusController(
       new FakeAuthAction(),
       new FakeEORIAction(eori),
       getData,
+      new FakeVerifiedEmailAction(),
       new FileUploadResponseRequiredAction(),
       mockAnswersConnector,
       mockAuditConnector,
@@ -109,7 +95,7 @@ class UpscanStatusControllerSpec extends ControllerSpecBase with SfusMetricsMock
   "Upscan Status error" should {
 
     "return error page" in {
-      val result = controller.error()(fakeRequest)
+      val result = controller().error()(fakeRequest)
 
       status(result) mustBe OK
       verify(uploadError).apply()(any(), any())

--- a/test/controllers/actions/DataRetrievalActionSpec.scala
+++ b/test/controllers/actions/DataRetrievalActionSpec.scala
@@ -19,7 +19,7 @@ package controllers.actions
 import controllers.ControllerSpecBase
 import generators.SignedInUserGen
 import models.UserAnswers
-import models.requests.{AuthenticatedRequest, DataRequest, EORIRequest, SignedInUser}
+import models.requests.{AuthenticatedRequest, DataRequest, EORIRequest, SignedInUser, VerifiedEmailRequest}
 import org.mockito.ArgumentMatchers.{eq => eqTo}
 import org.mockito.Mockito._
 import services.AnswersService
@@ -29,19 +29,19 @@ import scala.concurrent.Future
 class DataRetrievalActionSpec extends ControllerSpecBase with SignedInUserGen {
 
   class Harness(answersConnector: AnswersService) extends DataRetrievalActionImpl(answersConnector, mcc) {
-    def callTransform[A](request: EORIRequest[A]): Future[DataRequest[A]] = transform(request)
+    def callTransform[A](request: VerifiedEmailRequest[A]): Future[DataRequest[A]] = transform(request)
   }
 
   "Data Retrieval Action" when {
     "the connector finds data" must {
       "build a userAnswers object and add it to the request" in {
 
-        forAll { (user: SignedInUser, eori: String) =>
+        forAll { (user: SignedInUser, eori: String, email: String) =>
           val answers = UserAnswers(eori)
           val answersConnector = mock[AnswersService]
           when(answersConnector.findOrCreate(eqTo(eori))) thenReturn Future.successful(answers)
           val action = new Harness(answersConnector)
-          val request = EORIRequest(AuthenticatedRequest(fakeRequest, user), eori)
+          val request = VerifiedEmailRequest(EORIRequest(AuthenticatedRequest(fakeRequest, user), eori), email)
 
           val futureResult = action.callTransform(request)
 

--- a/test/controllers/actions/FakeActions.scala
+++ b/test/controllers/actions/FakeActions.scala
@@ -44,7 +44,7 @@ trait FakeActions extends Generators {
   class FakeDataRetrievalAction(answers: Option[UserAnswers] = None) extends DataRetrievalAction {
     protected def executionContext = ExecutionContext.global
     def parser = stubBodyParser()
-    override protected def transform[A](request: EORIRequest[A]): Future[DataRequest[A]] =
+    override protected def transform[A](request: VerifiedEmailRequest[A]): Future[DataRequest[A]] =
       Future.successful(DataRequest(request, answers.getOrElse(UserAnswers(request.eori))))
   }
 
@@ -59,6 +59,13 @@ trait FakeActions extends Generators {
   class FakeMrnRequiredAction(val mrn: MRN = arbitraryMrn.arbitrary.sample.get) extends MrnRequiredAction {
     protected def executionContext = ExecutionContext.global
     override protected def refine[A](request: DataRequest[A]): Future[Either[Result, MrnRequest[A]]] =
-      Future.successful(Right(MrnRequest(request.request, request.userAnswers, mrn)))
+      Future.successful(Right(MrnRequest(request.request.request, request.userAnswers, mrn)))
+  }
+
+  class FakeVerifiedEmailAction(email: String = emailString.sample.get) extends VerifiedEmailAction {
+    protected def executionContext = ExecutionContext.global
+    def parser = stubBodyParser()
+    override protected def refine[A](request: EORIRequest[A]): Future[Either[Result, VerifiedEmailRequest[A]]] =
+      Future.successful(Right(VerifiedEmailRequest[A](request, email)))
   }
 }

--- a/test/controllers/actions/VerifiedEmailActionSpec.scala
+++ b/test/controllers/actions/VerifiedEmailActionSpec.scala
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.actions
+
+import connectors.CdsFileUploadConnector
+import controllers.ControllerSpecBase
+import generators.SignedInUserGen
+import models.{EORI, VerifiedEmailAddress}
+import models.requests.{AuthenticatedRequest, EORIRequest, SignedInUser, VerifiedEmailRequest}
+import org.mockito.ArgumentMatchers.{eq => meq, _}
+import org.mockito.Mockito.{reset, when}
+import org.scalatest.{BeforeAndAfterEach, Inside}
+import play.api.{Configuration, Environment}
+import play.api.mvc.{MessagesControllerComponents, Result}
+import play.api.test.FakeRequest
+
+import java.time.ZonedDateTime
+import scala.concurrent.Future
+
+class VerifiedEmailActionSpec extends ControllerSpecBase with SignedInUserGen with BeforeAndAfterEach with Inside {
+
+  lazy val conf = instanceOf[Configuration]
+  lazy val env = instanceOf[Environment]
+  lazy val user = mock[SignedInUser]
+  lazy val backendConnector = mock[CdsFileUploadConnector]
+
+  lazy val action = new ActionTestWrapper(backendConnector, mcc)
+
+  lazy val sampleEmailAddress = "example@example.com"
+  lazy val sampleEori = EORI("12345")
+  lazy val verifiedEmail = VerifiedEmailAddress(sampleEmailAddress, ZonedDateTime.now())
+  lazy val authenticatedRequest = AuthenticatedRequest[Any](FakeRequest("GET", "requestPath"), user)
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    reset(backendConnector)
+  }
+
+  "VerifiedEmailAction" should {
+    "return a VerifiedEmailRequest" when {
+      "user has a verified email address" in {
+        when(backendConnector.getVerifiedEmailAddress(meq(sampleEori))(any())).thenReturn(Future.successful(Some(verifiedEmail)))
+
+        val request = EORIRequest(authenticatedRequest, sampleEori.value)
+
+        whenReady(action.testRefine(request)) { result =>
+          result mustBe Right(VerifiedEmailRequest(request, sampleEmailAddress))
+        }
+      }
+    }
+
+    "return a redirection Result" when {
+      "user has no verified email address" in {
+        when(backendConnector.getVerifiedEmailAddress(meq(sampleEori))(any())).thenReturn(Future.successful(None))
+
+        val request = EORIRequest(authenticatedRequest, sampleEori.value)
+
+        whenReady(action.testRefine(request)) { result =>
+          result must be('left)
+        }
+      }
+    }
+
+    "propagate exception" when {
+      "connector fails" in {
+        when(backendConnector.getVerifiedEmailAddress(meq(sampleEori))(any())).thenReturn(Future.failed(new Exception("Some unhappy response")))
+
+        val request = EORIRequest(authenticatedRequest, sampleEori.value)
+        val result = action.testRefine(request)
+
+        assert(result.failed.futureValue.isInstanceOf[Exception])
+      }
+    }
+  }
+
+  class ActionTestWrapper(backendConnector: CdsFileUploadConnector, mcc: MessagesControllerComponents)
+      extends VerifiedEmailActionImpl(backendConnector, mcc) {
+    def testRefine[A](request: EORIRequest[A]): Future[Either[Result, VerifiedEmailRequest[A]]] =
+      refine(request)
+  }
+}

--- a/test/views/DomAssertions.scala
+++ b/test/views/DomAssertions.scala
@@ -118,4 +118,15 @@ trait DomAssertions extends SpecBase {
 
   def assertSignoutLinkIsIncluded(view: HtmlFormat.Appendable): Assertion =
     assertContainsLink(asDocument(view), messages("signOut.link"), controllers.routes.SignOutController.signOut.url)
+
+  def assertBulletList(doc: Document, bulletText: String*) = {
+    val bullets = doc.select("li").asScala
+
+    val itemsWithExpected = bullets.zip(bulletText)
+
+    itemsWithExpected.foreach { itemWithExpected =>
+      val (item, expectedContent) = itemWithExpected
+      assert(item.text() == expectedContent)
+    }
+  }
 }

--- a/test/views/UnverifiedEmailSpec.scala
+++ b/test/views/UnverifiedEmailSpec.scala
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views
+
+import base.SpecBase
+import views.html.unverified_email
+import views.matchers.ViewMatchers
+import scala.collection.JavaConverters._
+
+class UnverifiedEmailSpec extends SpecBase with ViewMatchers {
+
+  lazy val redirectUrl = "/some/url"
+
+  val page = instanceOf[unverified_email]
+
+  val view = () => page(redirectUrl)(fakeRequest, messages)
+
+  val messageKeyPrefix = "emailUnverified"
+
+  "Unverified Email Page" must {
+
+    "display page header" in {
+      view().getElementsByTag("h1").first() must containMessage(s"$messageKeyPrefix.heading")
+    }
+
+    "have a 'Verify your email address' button with correct link" in {
+      val link = view().getElementsByClass("govuk-button").first()
+
+      link must haveHref(redirectUrl)
+      link must containMessage(s"${messageKeyPrefix}.link")
+    }
+
+    "have paragraph1 with text" in {
+      view().getElementById("emailUnverified.para1") must containMessage(s"${messageKeyPrefix}.paragraph1")
+    }
+
+    "have bullet list with expected items" in {
+      val ul = view().getElementById("emailUnverified.bullets")
+
+      val expectedBulletTextKeys = (1 to 4).map { idx =>
+        s"${messageKeyPrefix}.bullets.item${idx}"
+      }
+
+      val itemsWithExpectedKeys = ul.children().asScala.zip(expectedBulletTextKeys)
+
+      itemsWithExpectedKeys.foreach { itemWithExpected =>
+        val (item, expectedKey) = itemWithExpected
+        item must containMessage(expectedKey)
+      }
+    }
+  }
+}

--- a/test/views/UploadYourFilesReceiptSpec.scala
+++ b/test/views/UploadYourFilesReceiptSpec.scala
@@ -63,7 +63,7 @@ class UploadYourFilesReceiptSpec extends DomAssertions with ViewBehaviours with 
       forAll { fileUploads: List[FileUpload] =>
         val doc = asDocument(view(fileUploads))
 
-        assertEqualsMessage(doc, "title", s"$pagePrefix.title")
+        assertEqualsMessage(doc, "title", s"$pagePrefix.heading")
       }
     }
 

--- a/test/views/UploadYourFilesSpec.scala
+++ b/test/views/UploadYourFilesSpec.scala
@@ -53,21 +53,21 @@ class UploadYourFilesSpec extends DomAssertions with ViewBehaviours with ScalaCh
       "first file upload is shown" in {
 
         forAll { total: Int =>
-          assertEqualsMessage(asDocument(view(First(total))), "title", s"$messagePrefix.title.first")
+          assertEqualsMessage(asDocument(view(First(total))), "title", s"$messagePrefix.heading.first")
         }
       }
 
       "a middle file upload is shown" in {
 
         forAll { (index: Int, total: Int) =>
-          assertEqualsMessage(asDocument(view(Middle(index, total))), "title", s"$messagePrefix.title.middle")
+          assertEqualsMessage(asDocument(view(Middle(index, total))), "title", s"$messagePrefix.heading.middle")
         }
       }
 
       "the last file upload is shown" in {
 
         forAll { total: Int =>
-          assertEqualsMessage(asDocument(view(Last(total))), "title", s"$messagePrefix.title.last")
+          assertEqualsMessage(asDocument(view(Last(total))), "title", s"$messagePrefix.heading.last")
         }
       }
     }

--- a/test/views/behaviours/IntViewBehaviours.scala
+++ b/test/views/behaviours/IntViewBehaviours.scala
@@ -29,7 +29,7 @@ trait IntViewBehaviours[A] extends QuestionViewBehaviours[A] {
 
         "contain a label for the value" in {
           val doc = asDocument(createView(form))
-          assertContainsLabel(doc, fieldName, messages(s"$messageKeyPrefix.title"))
+          assertContainsLabel(doc, fieldName, messages(s"$messageKeyPrefix.heading"))
         }
 
         "contain an input for the value" in {
@@ -60,7 +60,7 @@ trait IntViewBehaviours[A] extends QuestionViewBehaviours[A] {
 
         "show an error prefix in the browser title" in {
           val doc = asDocument(createView(form.withError(error)))
-          assertPageTitleEquals(doc, s"""${messages("error.browser.title.prefix")} ${messages(s"$messageKeyPrefix.title")}""")
+          assertPageTitleEquals(doc, s"""${messages("error.browser.heading.prefix")} ${messages(s"$messageKeyPrefix.heading")}""")
         }
       }
     }

--- a/test/views/behaviours/StringViewBehaviours.scala
+++ b/test/views/behaviours/StringViewBehaviours.scala
@@ -63,7 +63,7 @@ trait StringViewBehaviours[A] extends QuestionViewBehaviours[A] {
 
         "show an error prefix in the browser title" in {
           val doc = asDocument(createView(form.withError(error)))
-          assertContainsValue(doc, "title", messages("error.browser.title.prefix"))
+          assertContainsValue(doc, "title", messages("error.browser.heading.prefix"))
         }
       }
     }

--- a/test/views/behaviours/ViewBehaviours.scala
+++ b/test/views/behaviours/ViewBehaviours.scala
@@ -39,7 +39,7 @@ trait ViewBehaviours extends DomAssertions {
 
         "display the correct browser title" in {
           val doc = asDocument(view())
-          assertEqualsMessage(doc, "title", s"$messageKeyPrefix.title")
+          assertEqualsMessage(doc, "title", s"$messageKeyPrefix.heading")
         }
       }
     }

--- a/test/views/matchers/ViewMatchers.scala
+++ b/test/views/matchers/ViewMatchers.scala
@@ -40,7 +40,7 @@ trait ViewMatchers {
 
   implicit class PageComplexChecks(document: Document) extends MustMatchers {
     def checkErrorsSummary(): Unit = {
-      document.getElementById("error-summary-heading").text() mustBe "error.summary.title"
+      document.getElementById("error-summary-heading").text() mustBe "error.summary.heading"
       document.select("div.error-summary.error-summary--show>p").text() must be("error.summary.text")
     }
   }


### PR DESCRIPTION
Add action to most pages to check that the
current user has a verified email address
associated with their EORI number.

If it is detected that the user does not
have a verified email address then they
are redirected to a page notifying them
of the fact and providing them with a link
to the customs-email-frontend service to
rectify the situation.