### PR TITLE
[CEDS-2978] Fix Email Frontend Link Config

### DIFF
--- a/app/config/AppConfig.scala
+++ b/app/config/AppConfig.scala
@@ -57,8 +57,7 @@ case class Services(
   cdsFileUploadFrontend: CDSFileUploadFrontend,
   cdsFileUpload: CDSFileUpload,
   keystore: Keystore,
-  contactFrontend: ContactFrontend,
-  customsEmailFrontend: CustomsEmailFrontend
+  contactFrontend: ContactFrontend
 )
 
 case class CustomsDeclarations(protocol: Option[String], host: String, port: Option[Int], batchUploadUri: String, apiVersion: String) {
@@ -93,10 +92,6 @@ case class Keystore(protocol: String = "https", host: String, port: Int, default
 
 case class ContactFrontend(url: String, serviceId: String) {
   lazy val giveFeedbackLink: String = s"$url?service=$serviceId"
-}
-
-case class CustomsEmailFrontend(protocol: String = "https", host: String, port: Int) {
-  lazy val getRedirectionLink: String = s"$protocol://$host:$port/manage-email-cds/service/cds-file-upload"
 }
 
 case class FileFormats(maxFileSizeMb: Int, approvedFileTypes: String, approvedFileExtensions: String)

--- a/app/config/ExternalServicesConfig.scala
+++ b/app/config/ExternalServicesConfig.scala
@@ -30,4 +30,5 @@ class ExternalServicesConfig @Inject()(val configuration: Configuration) {
   lazy val cdsCheckStatus = loadUrl("cdsCheckStatus")
   lazy val feedbackFrontend = loadUrl("feedbackFrontend")
   lazy val nationalClearingHubLink = loadUrl("nationalClearingHubLink")
+  lazy val emailFrontendUrl = loadUrl("emailFrontendUrl")
 }

--- a/app/controllers/UnverifiedEmailController.scala
+++ b/app/controllers/UnverifiedEmailController.scala
@@ -16,7 +16,7 @@
 
 package controllers
 
-import config.AppConfig
+import config.{AppConfig, ExternalServicesConfig}
 import controllers.actions.{AuthAction, EORIRequiredAction}
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
@@ -31,11 +31,11 @@ class UnverifiedEmailController @Inject()(
   requireEori: EORIRequiredAction,
   mcc: MessagesControllerComponents,
   unverified_email: unverified_email,
-  appConfig: AppConfig
+  config: ExternalServicesConfig
 ) extends FrontendController(mcc) with I18nSupport {
 
   val informUser: Action[AnyContent] = (authenticate andThen requireEori) { implicit req =>
-    val redirectUrl = appConfig.microservice.services.customsEmailFrontend.getRedirectionLink
+    val redirectUrl = config.emailFrontendUrl
     Ok(unverified_email(redirectUrl))
   }
 }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -126,12 +126,6 @@ microservice {
       service-id = "SFUS"
     }
 
-    customs-email-frontend {
-      protocol = http
-      host = localhost
-      port = 9898
-    }
-
     features {
       default = disabled
       secureMessaging = disabled
@@ -216,6 +210,7 @@ urls {
   cdsCheckStatus = "https://www.tax.service.gov.uk/customs/register-for-cds/are-you-based-in-uk"
   feedbackFrontend = "http://locahost:9514/feedback/cds-file-upload-frontend"
   nationalClearingHubLink = "https://www.gov.uk/government/organisations/hm-revenue-customs/contact/national-clearance-hub"
+  emailFrontendUrl = "http://localhost:9898/manage-email-cds/service/cds-file-upload"
 }
 
 answers-repository {

--- a/test/base/AppConfigMockHelper.scala
+++ b/test/base/AppConfigMockHelper.scala
@@ -24,7 +24,6 @@ import config.{
   CDSFileUploadFrontend,
   ContactFrontend,
   CustomsDeclarations,
-  CustomsEmailFrontend,
   Feedback,
   FileFormats,
   GoogleAnalytics,
@@ -73,6 +72,5 @@ object AppConfigMockHelper extends MockitoSugar {
     cdsFileUpload: CDSFileUpload = mock[CDSFileUpload],
     keystore: Keystore = mock[Keystore],
     contactFrontend: ContactFrontend = mock[ContactFrontend],
-    customsEmailFrontend: CustomsEmailFrontend = mock[CustomsEmailFrontend]
-  ) = Services(customsDeclarations, cdsFileUploadFrontend, cdsFileUpload, keystore, contactFrontend, customsEmailFrontend)
+  ) = Services(customsDeclarations, cdsFileUploadFrontend, cdsFileUpload, keystore, contactFrontend)
 }

--- a/test/config/AppConfigSpec.scala
+++ b/test/config/AppConfigSpec.scala
@@ -61,9 +61,5 @@ class AppConfigSpec extends PlaySpec {
 
       config.microservice.services.contactFrontend.giveFeedbackLink mustBe expectedUrl
     }
-
-    "have a correct configuration for Customs Email Frontend" in {
-      config.microservice.services.customsEmailFrontend.getRedirectionLink mustBe "http://localhost:9898/manage-email-cds/service/cds-file-upload"
-    }
   }
 }

--- a/test/config/ExternalServiceConfigSpec.scala
+++ b/test/config/ExternalServiceConfigSpec.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package config
+
+import base.SpecBase
+
+class ExternalServiceConfigSpec extends SpecBase {
+  val config = instanceOf[ExternalServicesConfig]
+
+  "have a correct configuration for EORI service url" in {
+    config.eoriService mustBe "https://www.gov.uk/eori"
+  }
+
+  "have a correct configuration for Registration url" in {
+    config.cdsRegister mustBe "https://www.gov.uk/guidance/get-access-to-the-customs-declaration-service"
+  }
+
+  "have a correct configuration for Check Status url" in {
+    config.cdsCheckStatus mustBe "https://www.tax.service.gov.uk/customs/register-for-cds/are-you-based-in-uk"
+  }
+
+  "have a correct configuration for Feedback url" in {
+    config.feedbackFrontend mustBe "http://locahost:9514/feedback/cds-file-upload-frontend"
+  }
+
+  "have a correct configuration for National Clearance Hub url" in {
+    config.nationalClearingHubLink mustBe "https://www.gov.uk/government/organisations/hm-revenue-customs/contact/national-clearance-hub"
+  }
+
+  "have a correct configuration for Customs Email Frontend url" in {
+    config.emailFrontendUrl mustBe "http://localhost:9898/manage-email-cds/service/cds-file-upload"
+  }
+}

--- a/test/controllers/UnverifiedEmailControllerSpec.scala
+++ b/test/controllers/UnverifiedEmailControllerSpec.scala
@@ -16,6 +16,7 @@
 
 package controllers
 
+import config.ExternalServicesConfig
 import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito.{reset, when}
 import play.api.test.Helpers._
@@ -25,11 +26,12 @@ import views.html.unverified_email
 class UnverifiedEmailControllerSpec extends ControllerSpecBase {
 
   val page = mock[unverified_email]
+  val config = instanceOf[ExternalServicesConfig]
 
   def view(): String = page("")(fakeRequest, messages).toString
 
   def controller() =
-    new UnverifiedEmailController(new FakeAuthAction(), new FakeEORIAction(), mcc, page, appConfig)
+    new UnverifiedEmailController(new FakeAuthAction(), new FakeEORIAction(), mcc, page, config)
 
   override protected def beforeEach(): Unit = {
     super.beforeEach


### PR DESCRIPTION
Use the 'url' section in the config to provide
the url as a relative link in the MDTP
environments.