### PR TITLE
[CEDS-2821] Receiving MRN via URL param to skip entry page

### DIFF
--- a/app/controllers/HowManyFilesUploadController.scala
+++ b/app/controllers/HowManyFilesUploadController.scala
@@ -20,7 +20,7 @@ import connectors.UpscanConnector
 import controllers.actions._
 import forms.FileUploadCountProvider
 import models._
-import models.requests.{ContactDetailsRequest, MrnRequest}
+import models.requests.ContactDetailsRequest
 import play.api.Logger
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}

--- a/app/controllers/UnverifiedEmailController.scala
+++ b/app/controllers/UnverifiedEmailController.scala
@@ -16,7 +16,7 @@
 
 package controllers
 
-import config.{AppConfig, ExternalServicesConfig}
+import config.ExternalServicesConfig
 import controllers.actions.{AuthAction, EORIRequiredAction}
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}

--- a/app/views/mrn_access_denied.scala.html
+++ b/app/views/mrn_access_denied.scala.html
@@ -28,11 +28,11 @@
   link: link
 )
 
-@(mrn: MRN)(implicit request: Request[_], messages: Messages)
+@(mrn: String)(implicit request: Request[_], messages: Messages)
 
-@mainTemplate(title = Title("mrnAccessDenied.heading", mrn.value)) {
+@mainTemplate(title = Title("mrnAccessDenied.heading", mrn)) {
 
-  @pageTitle(messages("mrnAccessDenied.heading", mrn.value))
+  @pageTitle(messages("mrnAccessDenied.heading", mrn))
 
   @paragraphBody(messages("mrnAccessDenied.paragraph.1"))
 
@@ -49,5 +49,4 @@
       call = controllers.routes.MrnEntryController.onPageLoad()
     )
   </div>
-
 }

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -12,6 +12,7 @@ GET         /unauthorised                       controllers.UnauthorisedControll
 
 GET         /mrn-entry                          controllers.MrnEntryController.onPageLoad
 POST        /mrn-entry                          controllers.MrnEntryController.onSubmit
+GET         /mrn-entry/:mrn                     controllers.MrnEntryController.autoFill(mrn)
 
 GET         /contact-details                    controllers.ContactDetailsController.onPageLoad
 POST        /contact-details                    controllers.ContactDetailsController.onSubmit

--- a/test/forms/mappings/ContactDetailsMappingSpec.scala
+++ b/test/forms/mappings/ContactDetailsMappingSpec.scala
@@ -69,7 +69,7 @@ class ContactDetailsMappingSpec extends SpecBase with MustMatchers with ScalaChe
 
       "Phone number is invalid" in {
 
-        forAll(arbitrary[ContactDetails], alphaNumString()) { (contactDetails, invalidPhoneNumber) =>
+        forAll(arbitrary[ContactDetails], alphaString()) { (contactDetails, invalidPhoneNumber) =>
           val badData = contactDetails.copy(phoneNumber = invalidPhoneNumber.take(15))
 
           Form(contactDetailsMapping)

--- a/test/views/MrnAccessDeniedSpec.scala
+++ b/test/views/MrnAccessDeniedSpec.scala
@@ -17,7 +17,6 @@
 package views
 
 import base.SpecBase
-import models.MRN
 import play.api.test.FakeRequest
 import play.twirl.api.Html
 import testdata.CommonTestData
@@ -30,11 +29,11 @@ class MrnAccessDeniedSpec extends SpecBase with ViewMatchers {
   private implicit val request = FakeRequest().withCSRFToken
 
   private val mrnAccessDeniedPage = instanceOf[mrn_access_denied]
-  private def view(mrn: MRN): Html = mrnAccessDeniedPage(mrn)(request, messages)
+  private def view(mrn: String): Html = mrnAccessDeniedPage(mrn)(request, messages)
 
   "MrnAccessDenied page" should {
 
-    val testView = view(MRN(CommonTestData.mrn).get)
+    val testView = view(CommonTestData.mrn)
 
     "display page header with provided MRN" in {
       testView.getElementsByTag("h1").first() must containMessage("mrnAccessDenied.heading", CommonTestData.mrn)


### PR DESCRIPTION
As part of the usability improvements we are allowing the link
to SFUS from the Exports UI to include the MRN of the declaration
to pre-populate that field and remove the need for the user
to re-type it.