### PR TITLE
BAU Decrease number of Mongo connections in tests

### DIFF
--- a/test/base/Injector.scala
+++ b/test/base/Injector.scala
@@ -32,7 +32,9 @@ trait Injector {
     */
   SharedMetricRegistries.clear()
 
-  private val injector = GuiceApplicationBuilder().injector()
+  def instanceOf[T <: AnyRef](implicit classTag: ClassTag[T]): T = Injector.injector.instanceOf[T]
+}
 
-  def instanceOf[T <: AnyRef](implicit classTag: ClassTag[T]): T = injector.instanceOf[T]
+object Injector {
+  private lazy val injector = GuiceApplicationBuilder().injector()
 }


### PR DESCRIPTION
Unit tests make use of Injector trait which creates new application
every time the trait is initialized. This results in hundreds of
connections being created every time all tests are run.

Application instance that was created in Injector trait is not possible
to be overridden so there should be no downsides of having a single
instance for all tests.