### PR TITLE
BAU Enabled secureMessaging feature flag

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -136,7 +136,7 @@ microservice {
 
     features {
       default = disabled
-      secureMessaging = disabled
+      secureMessaging = enabled
     }
   }
 }


### PR DESCRIPTION
This is to make local development and testing easier.
The flag is overridden to disabled in base configuration for
environments.