### PR TITLE
[CEDS-3070] Filter messages inbox

### DIFF
--- a/app/Module.scala
+++ b/app/Module.scala
@@ -36,6 +36,7 @@ class Module extends AbstractModule {
     bind(classOf[ContactDetailsRequiredAction]).to(classOf[ContactDetailsRequiredActionImpl]).asEagerSingleton()
     bind(classOf[MrnRequiredAction]).to(classOf[MrnRequiredActionImpl]).asEagerSingleton()
     bind(classOf[DataRetrievalAction]).to(classOf[DataRetrievalActionImpl]).asEagerSingleton()
+    bind(classOf[MessageFilterAction]).to(classOf[MessageFilterActionImpl]).asEagerSingleton()
   }
 
   @Provides @Singleton

--- a/app/config/AppConfig.scala
+++ b/app/config/AppConfig.scala
@@ -29,7 +29,8 @@ case class AppConfig(
   notifications: Notifications,
   feedback: Feedback,
   proxy: Proxy,
-  answersRepository: AnswersRepository,
+  fileUploadAnswersRepository: FileUploadAnswersRepository,
+  secureMessageAnswersRepository: SecureMessageAnswersRepository,
   trackingConsentFrontend: TrackingConsentFrontend,
   platform: Platform
 )
@@ -103,7 +104,9 @@ case class Feedback(url: String)
 
 case class Proxy(protocol: String, host: String, port: Int, username: String, password: String, proxyRequiredForThisEnvironment: Boolean)
 
-case class AnswersRepository(ttlSeconds: Int)
+case class FileUploadAnswersRepository(ttlSeconds: Int)
+
+case class SecureMessageAnswersRepository(ttlSeconds: Int)
 
 case class Gtm(container: String)
 

--- a/app/controllers/ContactDetailsController.scala
+++ b/app/controllers/ContactDetailsController.scala
@@ -23,7 +23,7 @@ import javax.inject.Inject
 import play.api.data.Form
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
-import services.AnswersService
+import services.FileUploadAnswersService
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import views.html.contact_details
 
@@ -35,7 +35,7 @@ class ContactDetailsController @Inject()(
   getData: DataRetrievalAction,
   requireMrn: MrnRequiredAction,
   verifiedEmail: VerifiedEmailAction,
-  answersConnector: AnswersService,
+  answersService: FileUploadAnswersService,
   mcc: MessagesControllerComponents,
   contactDetails: contact_details
 )(implicit ec: ExecutionContext)
@@ -54,7 +54,7 @@ class ContactDetailsController @Inject()(
       .fold(
         errorForm => Future.successful(BadRequest(contactDetails(errorForm, req.mrn))),
         contactDetails => {
-          answersConnector.upsert(req.userAnswers.copy(contactDetails = Some(contactDetails))).map { _ =>
+          answersService.upsert(req.userAnswers.copy(contactDetails = Some(contactDetails))).map { _ =>
             Redirect(routes.HowManyFilesUploadController.onPageLoad())
           }
         }

--- a/app/controllers/HowManyFilesUploadController.scala
+++ b/app/controllers/HowManyFilesUploadController.scala
@@ -25,7 +25,7 @@ import models.requests.ContactDetailsRequest
 import play.api.Logger
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
-import services.{AnswersService, CustomsDeclarationsService}
+import services.{CustomsDeclarationsService, FileUploadAnswersService}
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import views.html.how_many_files_upload
@@ -40,7 +40,7 @@ class HowManyFilesUploadController @Inject()(
   requireContactDetails: ContactDetailsRequiredAction,
   verifiedEmail: VerifiedEmailAction,
   formProvider: FileUploadCountProvider,
-  answersConnector: AnswersService,
+  answersService: FileUploadAnswersService,
   upscanConnector: UpscanConnector,
   customsDeclarationsService: CustomsDeclarationsService,
   mcc: MessagesControllerComponents,
@@ -87,7 +87,7 @@ class HowManyFilesUploadController @Inject()(
       val remainingFileUploads = fileUploadResponse.uploads.tail
       logger.info("remainingFileUploads " + remainingFileUploads)
 
-      answersConnector
+      answersService
         .upsert(req.userAnswers.copy(fileUploadCount = Some(fileUploadCount), fileUploadResponse = Some(FileUploadResponse(remainingFileUploads))))
         .map { _ =>
           logger.info("saving remaining uploads")

--- a/app/controllers/MrnEntryController.scala
+++ b/app/controllers/MrnEntryController.scala
@@ -23,7 +23,7 @@ import models.{EORI, MRN}
 import models.requests.DataRequest
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents, Result}
-import services.{AnswersService, MrnDisValidator}
+import services.{FileUploadAnswersService, MrnDisValidator}
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import views.html.{mrn_access_denied, mrn_entry}
@@ -37,7 +37,7 @@ class MrnEntryController @Inject()(
   getData: DataRetrievalAction,
   verifiedEmail: VerifiedEmailAction,
   formProvider: MRNFormProvider,
-  answersConnector: AnswersService,
+  answersService: FileUploadAnswersService,
   mcc: MessagesControllerComponents,
   mrnEntry: mrn_entry,
   mrnDisValidator: MrnDisValidator,
@@ -68,7 +68,7 @@ class MrnEntryController @Inject()(
     mrnDisValidator.validate(mrn, EORI(req.request.eori)).flatMap {
       case false => invalidMrnResponse(mrn.value)
       case true =>
-        answersConnector.upsert(req.userAnswers.copy(mrn = Some(mrn))).map { _ =>
+        answersService.upsert(req.userAnswers.copy(mrn = Some(mrn))).map { _ =>
           Redirect(routes.ContactDetailsController.onPageLoad())
         }
     }

--- a/app/controllers/UploadYourFilesReceiptController.scala
+++ b/app/controllers/UploadYourFilesReceiptController.scala
@@ -29,7 +29,7 @@ import models.requests.VerifiedEmailRequest
 import play.api.i18n.I18nSupport
 import play.api.mvc._
 import play.twirl.api.Html
-import services.AnswersService
+import services.FileUploadAnswersService
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import views.html.{upload_your_files_confirmation, upload_your_files_receipt}
@@ -44,7 +44,7 @@ class UploadYourFilesReceiptController @Inject()(
   metrics: SfusMetrics,
   uploadYourFilesReceipt: upload_your_files_receipt,
   uploadYourFilesConfirmation: upload_your_files_confirmation,
-  answersService: AnswersService,
+  answersService: FileUploadAnswersService,
   secureMessagingConfig: SecureMessagingConfig
 )(implicit mcc: MessagesControllerComponents, ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport {

--- a/app/controllers/UpscanStatusController.scala
+++ b/app/controllers/UpscanStatusController.scala
@@ -28,7 +28,7 @@ import models.requests.FileUploadResponseRequest
 import play.api.Logger
 import play.api.i18n.I18nSupport
 import play.api.mvc._
-import services.AnswersService
+import services.FileUploadAnswersService
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.audit.AuditExtensions._
 import uk.gov.hmrc.play.audit.http.connector.AuditConnector
@@ -44,7 +44,7 @@ class UpscanStatusController @Inject()(
   requireMrn: MrnRequiredAction,
   verifiedEmail: VerifiedEmailAction,
   requireResponse: FileUploadResponseRequiredAction,
-  answersConnector: AnswersService,
+  answersService: FileUploadAnswersService,
   auditConnector: AuditConnector,
   cdsFileUploadConnector: CdsFileUploadConnector,
   implicit val appConfig: AppConfig,
@@ -90,7 +90,7 @@ class UpscanStatusController @Inject()(
         case Some(upload) =>
           val updatedFiles = upload.copy(state = Uploaded) :: uploads.filterNot(_.id == id)
           val answers = req.userAnswers.copy(fileUploadResponse = Some(FileUploadResponse(updatedFiles)))
-          answersConnector.upsert(answers).flatMap { _ =>
+          answersService.upsert(answers).flatMap { _ =>
             nextPage(upload.reference, uploads)
           }
         case None =>
@@ -158,7 +158,7 @@ class UpscanStatusController @Inject()(
     retrieveNotifications()
   }
 
-  private def clearUserCache(eori: String) = answersConnector.removeByEori(eori)
+  private def clearUserCache(eori: String) = answersService.removeByEori(eori)
 
   private def auditUploadSuccess()(implicit req: FileUploadResponseRequest[_]): Unit = {
     def auditDetails: Map[String, String] = {

--- a/app/controllers/actions/DataRetrievalAction.scala
+++ b/app/controllers/actions/DataRetrievalAction.scala
@@ -18,17 +18,17 @@ package controllers.actions
 
 import models.requests.{DataRequest, VerifiedEmailRequest}
 import play.api.mvc.{ActionTransformer, MessagesControllerComponents}
-import services.AnswersService
+import services.FileUploadAnswersService
 
 import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 
-class DataRetrievalActionImpl @Inject()(val answersConnector: AnswersService, mcc: MessagesControllerComponents) extends DataRetrievalAction {
+class DataRetrievalActionImpl @Inject()(val answersService: FileUploadAnswersService, mcc: MessagesControllerComponents) extends DataRetrievalAction {
 
   implicit val executionContext: ExecutionContext = mcc.executionContext
 
   override protected def transform[A](request: VerifiedEmailRequest[A]): Future[DataRequest[A]] =
-    answersConnector.findOrCreate(request.eori).map(DataRequest(request, _))
+    answersService.findOrCreate(request.eori).map(DataRequest(request, _))
 }
 
 trait DataRetrievalAction extends ActionTransformer[VerifiedEmailRequest, DataRequest]

--- a/app/controllers/actions/MessageFilterAction.scala
+++ b/app/controllers/actions/MessageFilterAction.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.actions
+
+import controllers.routes
+import controllers.Assets.Redirect
+import models.requests.{MessageFilterRequest, VerifiedEmailRequest}
+import play.api.mvc.{ActionRefiner, MessagesControllerComponents, Result}
+import services.SecureMessageAnswersService
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+class MessageFilterActionImpl @Inject()(val answersService: SecureMessageAnswersService, mcc: MessagesControllerComponents)
+    extends MessageFilterAction {
+
+  implicit val executionContext: ExecutionContext = mcc.executionContext
+
+  private lazy val onError = Redirect(routes.InboxChoiceController.onPageLoad())
+
+  override protected def refine[A](request: VerifiedEmailRequest[A]): Future[Either[Result, MessageFilterRequest[A]]] =
+    answersService.findByEori(request.eori).map { maybeFilter =>
+      maybeFilter match {
+        case Some(filter) =>
+          Right(MessageFilterRequest(request, filter))
+        case None => Left(onError)
+      }
+    }
+}
+
+trait MessageFilterAction extends ActionRefiner[VerifiedEmailRequest, MessageFilterRequest]

--- a/app/forms/InboxChoiceForm.scala
+++ b/app/forms/InboxChoiceForm.scala
@@ -18,6 +18,7 @@ package forms
 
 import forms.mappings.EnhancedMapping.requiredRadio
 import forms.validators.FieldValidator
+import models.{ExportMessages, ImportMessages}
 import play.api.data.{Form, Forms}
 
 case class InboxChoiceForm(choice: String)
@@ -27,8 +28,8 @@ object InboxChoiceForm {
   val InboxChoiceKey = "choice"
 
   object Values {
-    val ExportsMessages = "ExportsMessages"
-    val ImportsMessages = "ImportsMessages"
+    val ExportsMessages = ExportMessages.toString
+    val ImportsMessages = ImportMessages.toString
   }
 
   val form: Form[InboxChoiceForm] = {

--- a/app/models/FileUploadAnswers.scala
+++ b/app/models/FileUploadAnswers.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+import org.joda.time.{DateTime, DateTimeZone}
+import play.api.libs.json.{Format, Json}
+import uk.gov.hmrc.mongo.json.ReactiveMongoFormats
+
+case class FileUploadAnswers(
+  eori: String,
+  mrn: Option[MRN] = None,
+  contactDetails: Option[ContactDetails] = None,
+  fileUploadCount: Option[FileUploadCount] = None,
+  fileUploadResponse: Option[FileUploadResponse] = None,
+  updated: DateTime = DateTime.now.withZone(DateTimeZone.UTC)
+)
+
+object FileUploadAnswers {
+  implicit val dateFormat: Format[DateTime] = ReactiveMongoFormats.dateTimeFormats
+  implicit val answersFormat = Json.format[FileUploadAnswers]
+}

--- a/app/models/MessageFilterTag.scala
+++ b/app/models/MessageFilterTag.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+import play.api.libs.json._
+
+sealed trait MessageFilterTag {
+  val filterValue: String
+}
+
+case object ExportMessages extends MessageFilterTag { val filterValue = "CDS-EXPORTS" }
+case object ImportMessages extends MessageFilterTag { val filterValue = "CDS-IMPORTS" }
+
+object MessageFilterTag {
+
+  val values = Seq(ExportMessages, ImportMessages)
+
+  def valueOf(name: String): Option[MessageFilterTag] =
+    values.foldLeft(Option.empty[MessageFilterTag]) { (acc, tag) =>
+      if (tag.toString.equalsIgnoreCase(name))
+        Some(tag)
+      else
+        acc
+    }
+
+  implicit val reads: Reads[MessageFilterTag] =
+    __.read[String]
+      .map(valueOf(_))
+      .collect(JsonValidationError("MessageFilterTag did not pass validation")) {
+        case Some(tag) => tag
+      }
+
+  implicit val writesTag: Writes[MessageFilterTag] = Writes {
+    case value: MessageFilterTag => JsString(value.toString)
+  }
+}

--- a/app/models/SecureMessageAnswers.scala
+++ b/app/models/SecureMessageAnswers.scala
@@ -20,16 +20,9 @@ import org.joda.time.{DateTime, DateTimeZone}
 import play.api.libs.json.{Format, Json}
 import uk.gov.hmrc.mongo.json.ReactiveMongoFormats
 
-case class UserAnswers(
-  eori: String,
-  mrn: Option[MRN] = None,
-  contactDetails: Option[ContactDetails] = None,
-  fileUploadCount: Option[FileUploadCount] = None,
-  fileUploadResponse: Option[FileUploadResponse] = None,
-  updated: DateTime = DateTime.now.withZone(DateTimeZone.UTC)
-)
+case class SecureMessageAnswers(eori: String, filter: MessageFilterTag, created: DateTime = DateTime.now.withZone(DateTimeZone.UTC))
 
-object UserAnswers {
+object SecureMessageAnswers {
   implicit val dateFormat: Format[DateTime] = ReactiveMongoFormats.dateTimeFormats
-  implicit val answersFormat = Json.format[UserAnswers]
+  implicit val format = Json.format[SecureMessageAnswers]
 }

--- a/app/models/requests/ContactDetailsRequest.scala
+++ b/app/models/requests/ContactDetailsRequest.scala
@@ -19,7 +19,7 @@ package models.requests
 import models._
 import play.api.mvc.WrappedRequest
 
-case class ContactDetailsRequest[A](request: MrnRequest[A], userAnswers: UserAnswers, contactDetails: ContactDetails)
+case class ContactDetailsRequest[A](request: MrnRequest[A], userAnswers: FileUploadAnswers, contactDetails: ContactDetails)
     extends WrappedRequest[A](request) with Authenticated {
   val eori = request.eori
 }

--- a/app/models/requests/DataRequest.scala
+++ b/app/models/requests/DataRequest.scala
@@ -19,4 +19,4 @@ package models.requests
 import models._
 import play.api.mvc.WrappedRequest
 
-case class DataRequest[A](request: VerifiedEmailRequest[A], userAnswers: UserAnswers) extends WrappedRequest[A](request) with Authenticated
+case class DataRequest[A](request: VerifiedEmailRequest[A], userAnswers: FileUploadAnswers) extends WrappedRequest[A](request) with Authenticated

--- a/app/models/requests/FileUploadResponseRequest.scala
+++ b/app/models/requests/FileUploadResponseRequest.scala
@@ -19,7 +19,7 @@ package models.requests
 import models._
 import play.api.mvc.WrappedRequest
 
-case class FileUploadResponseRequest[A](request: MrnRequest[A], userAnswers: UserAnswers, fileUploadResponse: FileUploadResponse)
+case class FileUploadResponseRequest[A](request: MrnRequest[A], userAnswers: FileUploadAnswers, fileUploadResponse: FileUploadResponse)
     extends WrappedRequest[A](request) with Authenticated {
   val eori = request.eori
 }

--- a/app/models/requests/MessageFilterRequest.scala
+++ b/app/models/requests/MessageFilterRequest.scala
@@ -19,8 +19,5 @@ package models.requests
 import models._
 import play.api.mvc.WrappedRequest
 
-case class MrnRequest[A](request: AuthenticatedRequest[A], userAnswers: FileUploadAnswers, mrn: MRN)
-    extends WrappedRequest[A](request) with Authenticated {
-
-  def eori: String = request.eori
-}
+case class MessageFilterRequest[A](request: VerifiedEmailRequest[A], secureMessageAnswers: SecureMessageAnswers)
+    extends WrappedRequest[A](request) with Authenticated

--- a/app/pages/QuestionPage.scala
+++ b/app/pages/QuestionPage.scala
@@ -16,9 +16,9 @@
 
 package pages
 
-import models.UserAnswers
+import models.FileUploadAnswers
 
 trait QuestionPage[A] extends Page {
 
-  def cleanup(value: Option[A], userAnswers: UserAnswers): UserAnswers = userAnswers
+  def cleanup(value: Option[A], userAnswers: FileUploadAnswers): FileUploadAnswers = userAnswers
 }

--- a/app/repositories/FileUploadAnswersRepository.scala
+++ b/app/repositories/FileUploadAnswersRepository.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package repositories
+
+import config.AppConfig
+import javax.inject.{Inject, Singleton}
+import models.FileUploadAnswers
+import play.modules.reactivemongo.ReactiveMongoComponent
+import reactivemongo.api.indexes.{Index, IndexType}
+import reactivemongo.bson.{BSONDocument, BSONObjectID}
+import reactivemongo.play.json.collection.JSONCollection
+import uk.gov.hmrc.mongo.ReactiveRepository
+import uk.gov.hmrc.mongo.json.ReactiveMongoFormats
+
+@Singleton
+class FileUploadAnswersRepository @Inject()(mc: ReactiveMongoComponent, appConfig: AppConfig)
+    extends ReactiveRepository[FileUploadAnswers, BSONObjectID](
+      collectionName = "answers",
+      mongo = mc.mongoConnector.db,
+      domainFormat = FileUploadAnswers.answersFormat,
+      idFormat = ReactiveMongoFormats.objectIdFormats
+    ) {
+
+  override lazy val collection: JSONCollection =
+    mongo().collection[JSONCollection](collectionName, failoverStrategy = RepositorySettings.failoverStrategy)
+
+  override def indexes: Seq[Index] = Seq(
+    Index(Seq("eori" -> IndexType.Ascending), name = Some("eoriIdx")),
+    Index(
+      key = Seq("updated" -> IndexType.Ascending),
+      name = Some("ttl"),
+      options = BSONDocument("expireAfterSeconds" -> appConfig.fileUploadAnswersRepository.ttlSeconds)
+    )
+  )
+}

--- a/app/repositories/SecureMessageAnswersRepository.scala
+++ b/app/repositories/SecureMessageAnswersRepository.scala
@@ -17,8 +17,7 @@
 package repositories
 
 import config.AppConfig
-import javax.inject.{Inject, Singleton}
-import models.UserAnswers
+import models.SecureMessageAnswers
 import play.modules.reactivemongo.ReactiveMongoComponent
 import reactivemongo.api.indexes.{Index, IndexType}
 import reactivemongo.bson.{BSONDocument, BSONObjectID}
@@ -26,12 +25,14 @@ import reactivemongo.play.json.collection.JSONCollection
 import uk.gov.hmrc.mongo.ReactiveRepository
 import uk.gov.hmrc.mongo.json.ReactiveMongoFormats
 
+import javax.inject.{Inject, Singleton}
+
 @Singleton
-class AnswersRepository @Inject()(mc: ReactiveMongoComponent, appConfig: AppConfig)
-    extends ReactiveRepository[UserAnswers, BSONObjectID](
-      collectionName = "answers",
+class SecureMessageAnswersRepository @Inject()(mc: ReactiveMongoComponent, appConfig: AppConfig)
+    extends ReactiveRepository[SecureMessageAnswers, BSONObjectID](
+      collectionName = "answers-secure-message",
       mongo = mc.mongoConnector.db,
-      domainFormat = UserAnswers.answersFormat,
+      domainFormat = SecureMessageAnswers.format,
       idFormat = ReactiveMongoFormats.objectIdFormats
     ) {
 
@@ -41,10 +42,9 @@ class AnswersRepository @Inject()(mc: ReactiveMongoComponent, appConfig: AppConf
   override def indexes: Seq[Index] = Seq(
     Index(Seq("eori" -> IndexType.Ascending), name = Some("eoriIdx")),
     Index(
-      key = Seq("updated" -> IndexType.Ascending),
+      key = Seq("created" -> IndexType.Ascending),
       name = Some("ttl"),
-      options = BSONDocument("expireAfterSeconds" -> appConfig.answersRepository.ttlSeconds)
+      options = BSONDocument("expireAfterSeconds" -> appConfig.secureMessageAnswersRepository.ttlSeconds)
     )
   )
-
 }

--- a/app/services/FileUploadAnswersService.scala
+++ b/app/services/FileUploadAnswersService.scala
@@ -16,38 +16,36 @@
 
 package services
 
-import javax.inject.Inject
-import models.UserAnswers
+import models.FileUploadAnswers
 import org.joda.time.{DateTime, DateTimeZone}
-import play.api.Logger
+import play.api.Logging
 import play.api.libs.json.{JsObject, Json}
-import repositories.AnswersRepository
+import repositories.FileUploadAnswersRepository
 
+import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 
-class AnswersService @Inject()(val repository: AnswersRepository)(implicit ec: ExecutionContext) {
-
-  private val logger = Logger(this.getClass)
+class FileUploadAnswersService @Inject()(val repository: FileUploadAnswersRepository)(implicit ec: ExecutionContext) extends Logging {
 
   def removeByEori(eori: String): Future[Unit] = repository.remove("eori" -> eori).map(_ => (): Unit)
 
-  def findByEori(eori: String): Future[Option[UserAnswers]] = repository.find("eori" -> eori).map(_.headOption)
+  def findByEori(eori: String): Future[Option[FileUploadAnswers]] = repository.find("eori" -> eori).map(_.headOption)
 
-  def findOrCreate(eori: String): Future[UserAnswers] =
+  def findOrCreate(eori: String): Future[FileUploadAnswers] =
     findByEori(eori).flatMap {
       case Some(movementCache) => Future.successful(movementCache)
-      case None                => save(UserAnswers(eori))
+      case None                => save(FileUploadAnswers(eori))
     }
 
-  def upsert(answers: UserAnswers): Future[Option[UserAnswers]] = {
+  def upsert(answers: FileUploadAnswers): Future[Option[FileUploadAnswers]] = {
     val updated = answers.copy(updated = DateTime.now.withZone(DateTimeZone.UTC))
     repository
       .findAndUpdate(Json.obj("eori" -> updated.eori), Json.toJson(updated).as[JsObject], upsert = true)
-      .map(_.value.map(_.as[UserAnswers]))
+      .map(_.value.map(_.as[FileUploadAnswers]))
   }
 
-  private def save(answers: UserAnswers): Future[UserAnswers] = repository.insert(answers).map { res =>
-    if (!res.ok) logger.error(s"Errors when persisting answers: ${res.writeErrors.mkString("--")}")
+  private def save(answers: FileUploadAnswers): Future[FileUploadAnswers] = repository.insert(answers).map { res =>
+    if (!res.ok) logger.error(s"Errors when persisting file upload answers: ${res.writeErrors.mkString("--")}")
     answers
   }
 }

--- a/app/services/SecureMessageAnswersService.scala
+++ b/app/services/SecureMessageAnswersService.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services
+
+import models.SecureMessageAnswers
+import org.joda.time.{DateTime, DateTimeZone}
+import play.api.Logging
+import play.api.libs.json.{JsObject, Json}
+import repositories.SecureMessageAnswersRepository
+
+import javax.inject.Inject
+import scala.concurrent.{ExecutionContext, Future}
+
+class SecureMessageAnswersService @Inject()(val repository: SecureMessageAnswersRepository)(implicit ec: ExecutionContext) extends Logging {
+
+  def findByEori(eori: String): Future[Option[SecureMessageAnswers]] = repository.find("eori" -> eori).map(_.headOption)
+
+  def upsert(answers: SecureMessageAnswers): Future[Option[SecureMessageAnswers]] = {
+    val updated = answers.copy(created = DateTime.now.withZone(DateTimeZone.UTC))
+    repository
+      .findAndUpdate(Json.obj("eori" -> updated.eori), Json.toJson(updated).as[JsObject], upsert = true)
+      .map(_.value.map(_.as[SecureMessageAnswers]))
+  }
+}

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -223,7 +223,11 @@ urls {
   emailFrontendUrl = "http://localhost:9898/manage-email-cds/service/cds-file-upload"
 }
 
-answers-repository {
+file-upload-answers-repository {
+  ttl-seconds = 3600
+}
+
+secure-message-answers-repository {
   ttl-seconds = 3600
 }
 

--- a/test/base/AppConfigMockHelper.scala
+++ b/test/base/AppConfigMockHelper.scala
@@ -17,7 +17,6 @@
 package base
 
 import config.{
-  AnswersRepository,
   AppConfig,
   Assets,
   CDSFileUpload,
@@ -26,12 +25,14 @@ import config.{
   CustomsDeclarations,
   Feedback,
   FileFormats,
+  FileUploadAnswersRepository,
   GoogleAnalytics,
   Keystore,
   Microservice,
   Notifications,
   Platform,
   Proxy,
+  SecureMessageAnswersRepository,
   SecureMessaging,
   Services,
   TrackingConsentFrontend
@@ -49,7 +50,8 @@ object AppConfigMockHelper extends MockitoSugar {
     notifications: Notifications = mock[Notifications],
     feedback: Feedback = mock[Feedback],
     proxy: Proxy = mock[Proxy],
-    answersRepository: AnswersRepository = mock[AnswersRepository],
+    answersRepository: FileUploadAnswersRepository = mock[FileUploadAnswersRepository],
+    secureMessageAnswersRepository: SecureMessageAnswersRepository = mock[SecureMessageAnswersRepository],
     trackingConsentFrontend: TrackingConsentFrontend = mock[TrackingConsentFrontend],
     platform: Platform = mock[Platform]
   ) = AppConfig(
@@ -63,6 +65,7 @@ object AppConfigMockHelper extends MockitoSugar {
     feedback,
     proxy,
     answersRepository,
+    secureMessageAnswersRepository,
     trackingConsentFrontend,
     platform
   )

--- a/test/base/SpecBase.scala
+++ b/test/base/SpecBase.scala
@@ -21,7 +21,7 @@ import com.codahale.metrics.SharedMetricRegistries
 import config.AppConfig
 import generators.Generators
 import org.scalatest.BeforeAndAfterEach
-import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
@@ -34,7 +34,8 @@ import uk.gov.hmrc.http.HeaderCarrier
 import scala.concurrent.ExecutionContext
 
 trait SpecBase
-    extends PlaySpec with MockitoSugar with BeforeAndAfterEach with ScalaCheckPropertyChecks with Generators with ScalaFutures with Injector {
+    extends PlaySpec with MockitoSugar with BeforeAndAfterEach with ScalaCheckPropertyChecks with Generators with ScalaFutures
+    with IntegrationPatience with Injector {
 
   SharedMetricRegistries.clear()
 

--- a/test/config/AppConfigSpec.scala
+++ b/test/config/AppConfigSpec.scala
@@ -76,5 +76,13 @@ class AppConfigSpec extends PlaySpec {
       secureMessaging.replyResultEndpoint("client", "conversationId") mustBe
         "http://localhost:9055/secure-message-frontend/cds-file-upload-service/conversation/client/conversationId/result"
     }
+
+    "have a TTL defined for the FileUploadAnswersRepository" in {
+      config.fileUploadAnswersRepository.ttlSeconds mustBe 3600
+    }
+
+    "have a TTL defined for the SecureMessageAnswersRepository" in {
+      config.secureMessageAnswersRepository.ttlSeconds mustBe 3600
+    }
   }
 }

--- a/test/connectors/SecureMessageFrontendConnectorSpec.scala
+++ b/test/connectors/SecureMessageFrontendConnectorSpec.scala
@@ -16,17 +16,19 @@
 
 package connectors
 
-import scala.concurrent.{ExecutionContext, Future}
-
 import base.{Injector, UnitSpec}
 import config.AppConfig
-import models.{ConversationPartial, InboxPartial}
+import models.{ExportMessages, ImportMessages, InboxPartial}
+import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.{any, anyString}
-import org.mockito.Mockito.{reset, when}
-import org.scalatest.BeforeAndAfterEach
+import org.mockito.Mockito.{reset, verify, when}
 import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.BeforeAndAfterEach
 import play.mvc.Http.Status.{BAD_REQUEST, OK}
+import testdata.CommonTestData
 import uk.gov.hmrc.http._
+
+import scala.concurrent.{ExecutionContext, Future}
 
 class SecureMessageFrontendConnectorSpec extends UnitSpec with BeforeAndAfterEach with Injector with ScalaFutures {
   val appConfig = instanceOf[AppConfig]
@@ -42,17 +44,17 @@ class SecureMessageFrontendConnectorSpec extends UnitSpec with BeforeAndAfterEac
   val connector = new SecureMessageFrontendConnector(httpClient, appConfig)
 
   "SecureMessageFrontend" when {
-
     "retrieveInboxPartial is called" which {
       "receives a 200 response" should {
         "return a populated InboxPartial" in {
           val partialContent = "<div>Some Content</div>"
           val httpResponse = HttpResponse(status = OK, body = partialContent)
 
-          when(httpClient.GET[HttpResponse](anyString())(any(), any(), any()))
+          when(httpClient.GET[HttpResponse](anyString(), any())(any(), any(), any()))
             .thenReturn(Future.successful(httpResponse))
 
-          val result = connector.retrieveInboxPartial().futureValue
+          val result = connector.retrieveInboxPartial(CommonTestData.eori, ExportMessages).futureValue
+
           result mustBe InboxPartial(partialContent)
         }
       }
@@ -61,58 +63,75 @@ class SecureMessageFrontendConnectorSpec extends UnitSpec with BeforeAndAfterEac
         "return a failed Future" in {
           val httpResponse = HttpResponse(status = BAD_REQUEST, body = "")
 
-          when(httpClient.GET[HttpResponse](anyString())(any(), any(), any()))
+          when(httpClient.GET[HttpResponse](anyString(), any())(any(), any(), any()))
             .thenReturn(Future.successful(httpResponse))
 
-          val result = connector.retrieveInboxPartial()
+          val result = connector.retrieveInboxPartial(CommonTestData.eori, ExportMessages)
           assert(result.failed.futureValue.isInstanceOf[UpstreamErrorResponse])
         }
       }
 
       "fails to connect to downstream service" should {
         "return a failed Future" in {
-          when(httpClient.GET[HttpResponse](anyString())(any(), any(), any()))
+          when(httpClient.GET[HttpResponse](anyString(), any())(any(), any(), any()))
             .thenReturn(Future.failed(new BadGatewayException("Error")))
 
-          val result = connector.retrieveInboxPartial()
+          val result = connector.retrieveInboxPartial(CommonTestData.eori, ExportMessages)
           assert(result.failed.futureValue.isInstanceOf[BadGatewayException])
         }
       }
-    }
 
-    "retrieveConversationsPartial is called" which {
-      "receives a 200 response" should {
-        "return a populated ConversationPartial" in {
-          val partialContent = "<div>Some Content</div>"
-          val httpResponse = HttpResponse(status = OK, body = partialContent)
+      "is passed the user's eori number" should {
+        "include the Enrolment tag as a query string parameter with the correct eori value" in {
+          val httpResponse = HttpResponse(status = OK, body = "")
 
-          when(httpClient.GET[HttpResponse](anyString())(any(), any(), any()))
+          when(httpClient.GET[HttpResponse](anyString(), any())(any(), any(), any()))
             .thenReturn(Future.successful(httpResponse))
 
-          val result = connector.retrieveConversationPartial("cdm", "1234").futureValue
-          result mustBe ConversationPartial(partialContent)
+          connector.retrieveInboxPartial(CommonTestData.eori, ExportMessages).futureValue
+
+          val queryParamCaptor = ArgumentCaptor.forClass(classOf[Seq[(String, String)]])
+          verify(httpClient).GET[HttpResponse](anyString(), queryParamCaptor.capture())(any(), any(), any())
+          val queryParamValue = queryParamCaptor.getValue().asInstanceOf[Seq[(String, String)]]
+
+          queryParamValue.size mustBe 2
+          queryParamValue(0) mustBe Tuple2("enrolment", s"HMRC-CUS-ORG~EoriNumber~${CommonTestData.eori}")
         }
       }
 
-      "receives a non 200 response" should {
-        "return a failed Future" in {
-          val httpResponse = HttpResponse(status = BAD_REQUEST, body = "")
+      "is passed the message filter tag of ExportMessages" should {
+        "include the ExportMessages tag as a query string parameter" in {
+          val httpResponse = HttpResponse(status = OK, body = "")
 
-          when(httpClient.GET[HttpResponse](anyString())(any(), any(), any()))
+          when(httpClient.GET[HttpResponse](anyString(), any())(any(), any(), any()))
             .thenReturn(Future.successful(httpResponse))
 
-          val result = connector.retrieveConversationPartial("cdm", "1234")
-          assert(result.failed.futureValue.isInstanceOf[UpstreamErrorResponse])
+          connector.retrieveInboxPartial(CommonTestData.eori, ExportMessages).futureValue
+
+          val queryParamCaptor = ArgumentCaptor.forClass(classOf[Seq[(String, String)]])
+          verify(httpClient).GET[HttpResponse](anyString(), queryParamCaptor.capture())(any(), any(), any())
+          val queryParamValue = queryParamCaptor.getValue().asInstanceOf[Seq[(String, String)]]
+
+          queryParamValue.size mustBe 2
+          queryParamValue(1) mustBe Tuple2("tag", "notificationType~CDS-EXPORTS")
         }
       }
 
-      "fails to connect to downstream service" should {
-        "return a failed Future" in {
-          when(httpClient.GET[HttpResponse](anyString())(any(), any(), any()))
-            .thenReturn(Future.failed(new BadGatewayException("Error")))
+      "is passed the message filter tag of ImportMessages" should {
+        "include the ImportMessages tag as a query string parameter" in {
+          val httpResponse = HttpResponse(status = OK, body = "")
 
-          val result = connector.retrieveConversationPartial("cdm", "1234")
-          assert(result.failed.futureValue.isInstanceOf[BadGatewayException])
+          when(httpClient.GET[HttpResponse](anyString(), any())(any(), any(), any()))
+            .thenReturn(Future.successful(httpResponse))
+
+          connector.retrieveInboxPartial(CommonTestData.eori, ImportMessages).futureValue
+
+          val queryParamCaptor = ArgumentCaptor.forClass(classOf[Seq[(String, String)]])
+          verify(httpClient).GET[HttpResponse](anyString(), queryParamCaptor.capture())(any(), any(), any())
+          val queryParamValue = queryParamCaptor.getValue().asInstanceOf[Seq[(String, String)]]
+
+          queryParamValue.size mustBe 2
+          queryParamValue(1) mustBe Tuple2("tag", "notificationType~CDS-IMPORTS")
         }
       }
     }

--- a/test/controllers/ContactDetailsControllerSpec.scala
+++ b/test/controllers/ContactDetailsControllerSpec.scala
@@ -44,7 +44,7 @@ class ContactDetailsControllerSpec extends ControllerSpecBase {
       dataRetrieval,
       new FakeMrnRequiredAction,
       new FakeVerifiedEmailAction(),
-      mockAnswersConnector,
+      mockFileUploadAnswersService,
       mcc,
       page
     )(mcc.executionContext)
@@ -66,7 +66,7 @@ class ContactDetailsControllerSpec extends ControllerSpecBase {
     "load the correct page when user is logged in" in {
 
       forAll { (user: SignedInUser, eori: String) =>
-        val answers = UserAnswers(eori, mrn = Some(mrn))
+        val answers = FileUploadAnswers(eori, mrn = Some(mrn))
         val result = controller(user, eori, fakeDataRetrievalAction(answers)).onPageLoad(fakeRequest)
 
         status(result) mustBe OK
@@ -76,7 +76,7 @@ class ContactDetailsControllerSpec extends ControllerSpecBase {
     "contact details should be displayed if they exist in the cache" in {
 
       forAll { (user: SignedInUser, eori: String, contactDetails: ContactDetails) =>
-        val answers = UserAnswers(eori, mrn = Some(mrn), contactDetails = Some(contactDetails))
+        val answers = FileUploadAnswers(eori, mrn = Some(mrn), contactDetails = Some(contactDetails))
         val result = controller(user, eori, fakeDataRetrievalAction(answers)).onPageLoad(fakeRequest)
 
         contentAsString(result) mustBe view(form.fill(contactDetails))
@@ -88,7 +88,7 @@ class ContactDetailsControllerSpec extends ControllerSpecBase {
       forAll { (user: SignedInUser, eori: String, contactDetails: ContactDetails) =>
         whenever(contactDetails.email.matches(emailRegex)) {
           val postRequest = fakeRequest.withFormUrlEncodedBody(asFormParams(contactDetails): _*)
-          val answers = UserAnswers(eori, mrn = Some(mrn))
+          val answers = FileUploadAnswers(eori, mrn = Some(mrn))
           val result = controller(user, eori, fakeDataRetrievalAction(answers)).onSubmit(postRequest)
 
           status(result) mustBe SEE_OTHER
@@ -101,7 +101,7 @@ class ContactDetailsControllerSpec extends ControllerSpecBase {
 
       forAll(arbitrary[SignedInUser], eoriString, arbitrary[ContactDetails], minStringLength(36)) { (user, eori, contactDetails, invalidName) =>
         val badData = contactDetails.copy(name = invalidName)
-        val answers = UserAnswers(eori, mrn = Some(mrn))
+        val answers = FileUploadAnswers(eori, mrn = Some(mrn))
 
         val postRequest = fakeRequest.withFormUrlEncodedBody(asFormParams(badData): _*)
         val badForm = form.fillAndValidate(badData)
@@ -117,13 +117,13 @@ class ContactDetailsControllerSpec extends ControllerSpecBase {
 
       forAll { (user: SignedInUser, eori: String, contactDetails: ContactDetails) =>
         whenever(contactDetails.email.matches(emailRegex)) {
-          resetAnswersConnector()
+          resetAnswersService()
           val postRequest = fakeRequest.withFormUrlEncodedBody(asFormParams(contactDetails): _*)
-          val answers = UserAnswers(eori, mrn = Some(mrn))
+          val answers = FileUploadAnswers(eori, mrn = Some(mrn))
 
           await(controller(user, eori, fakeDataRetrievalAction(answers)).onSubmit(postRequest))
 
-          theSavedUserAnswers.contactDetails mustBe Some(contactDetails)
+          theSavedFileUploadAnswers.contactDetails mustBe Some(contactDetails)
         }
       }
     }

--- a/test/controllers/ControllerSpecBase.scala
+++ b/test/controllers/ControllerSpecBase.scala
@@ -21,11 +21,11 @@ import base.SpecBase
 import config.SecureMessagingConfig
 import controllers.actions.{ContactDetailsRequiredAction, DataRetrievalAction, FakeActions}
 import models.requests.SignedInUser
-import models.{ContactDetails, UserAnswers}
+import models.{ContactDetails, FileUploadAnswers, SecureMessageAnswers}
 import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.{any, eq => eqTo}
 import org.mockito.Mockito.{reset, verify, when}
-import services.AnswersService
+import services.{FileUploadAnswersService, SecureMessageAnswersService}
 import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals._
 import uk.gov.hmrc.auth.core.{AuthConnector, AuthorisationException, Enrolments}
 
@@ -34,7 +34,8 @@ import scala.concurrent.Future
 abstract class ControllerSpecBase extends SpecBase with FakeActions {
 
   val mockAuthConnector: AuthConnector = mock[AuthConnector]
-  val mockAnswersConnector: AnswersService = mock[AnswersService]
+  val mockFileUploadAnswersService: FileUploadAnswersService = mock[FileUploadAnswersService]
+  val mockSecureMessageAnswersService: SecureMessageAnswersService = mock[SecureMessageAnswersService]
   val secureMessageConfig: SecureMessagingConfig = mock[SecureMessagingConfig]
 
   def withSecureMessagingEnabled(enabled: Boolean)(test: => Unit): Unit = {
@@ -65,18 +66,24 @@ abstract class ControllerSpecBase extends SpecBase with FakeActions {
   }
 
   override protected def beforeEach(): Unit = {
-    resetAnswersConnector()
+    resetAnswersService()
     reset(secureMessageConfig)
   }
 
-  def resetAnswersConnector() = {
-    reset(mockAnswersConnector)
-    when(mockAnswersConnector.upsert(any[UserAnswers])).thenReturn(Future.successful(Some(UserAnswers(""))))
+  def resetAnswersService() = {
+    reset(mockFileUploadAnswersService)
+    when(mockFileUploadAnswersService.upsert(any[FileUploadAnswers])).thenReturn(Future.successful(Some(FileUploadAnswers(""))))
   }
 
-  def theSavedUserAnswers: UserAnswers = {
-    val captor = ArgumentCaptor.forClass(classOf[UserAnswers])
-    verify(mockAnswersConnector).upsert(captor.capture())
+  def theSavedFileUploadAnswers: FileUploadAnswers = {
+    val captor = ArgumentCaptor.forClass(classOf[FileUploadAnswers])
+    verify(mockFileUploadAnswersService).upsert(captor.capture())
+    captor.getValue
+  }
+
+  def theSavedSecureMessageAnswers: SecureMessageAnswers = {
+    val captor = ArgumentCaptor.forClass(classOf[SecureMessageAnswers])
+    verify(mockSecureMessageAnswersService).upsert(captor.capture())
     captor.getValue
   }
 
@@ -86,5 +93,5 @@ abstract class ControllerSpecBase extends SpecBase with FakeActions {
     new FakeContactDetailsRequiredAction(contactDetails)
 
   def fakeDataRetrievalAction(): DataRetrievalAction = new FakeDataRetrievalAction(None)
-  def fakeDataRetrievalAction(answers: UserAnswers): DataRetrievalAction = new FakeDataRetrievalAction(Some(answers))
+  def fakeDataRetrievalAction(answers: FileUploadAnswers): DataRetrievalAction = new FakeDataRetrievalAction(Some(answers))
 }

--- a/test/controllers/HowManyFilesUploadControllerSpec.scala
+++ b/test/controllers/HowManyFilesUploadControllerSpec.scala
@@ -48,7 +48,7 @@ class HowManyFilesUploadControllerSpec extends ControllerSpecBase with DomAssert
   val eori: String = eoriString.sample.get
   val mrn: MRN = arbitraryMrn.arbitrary.sample.get
   private val fileUploadCount = FileUploadCount(7)
-  val validAnswers = UserAnswers(eori, mrn = Some(mrn), fileUploadCount = fileUploadCount)
+  val validAnswers = FileUploadAnswers(eori, mrn = Some(mrn), fileUploadCount = fileUploadCount)
 
   implicit val arbitraryContactDetailsActions: Arbitrary[ContactDetailsRequiredAction] =
     Arbitrary(arbitrary[FakeContactDetailsRequiredAction].map(_.asInstanceOf[ContactDetailsRequiredAction]))
@@ -70,7 +70,7 @@ class HowManyFilesUploadControllerSpec extends ControllerSpecBase with DomAssert
 
   private def controller(
     contactDetailsRequiredAction: ContactDetailsRequiredAction = new FakeContactDetailsRequiredAction(),
-    answers: Option[UserAnswers] = Some(validAnswers)
+    answers: Option[FileUploadAnswers] = Some(validAnswers)
   ) =
     new HowManyFilesUploadController(
       new FakeAuthAction(),
@@ -79,7 +79,7 @@ class HowManyFilesUploadControllerSpec extends ControllerSpecBase with DomAssert
       contactDetailsRequiredAction,
       new FakeVerifiedEmailAction(),
       new FileUploadCountProvider,
-      mockAnswersConnector,
+      mockFileUploadAnswersService,
       mockUpscanConnector,
       mockCustomsDeclarationsService,
       mcc,
@@ -175,7 +175,7 @@ class HowManyFilesUploadControllerSpec extends ControllerSpecBase with DomAssert
       val nextRef = fileUploadsAfterContactDetails.map(_.reference).min
       redirectLocation(result) mustBe Some(routes.UpscanStatusController.onPageLoad(nextRef).url)
 
-      val savedAnswers = theSavedUserAnswers
+      val savedAnswers = theSavedFileUploadAnswers
       val Some(fileUploadCount) = FileUploadCount(2)
       savedAnswers.fileUploadCount mustBe Some(fileUploadCount)
       savedAnswers.fileUploadResponse mustBe Some(FileUploadResponse(fileUploadResponse.uploads.tail))

--- a/test/controllers/MrnEntryControllerSpec.scala
+++ b/test/controllers/MrnEntryControllerSpec.scala
@@ -17,7 +17,7 @@
 package controllers
 
 import forms.MRNFormProvider
-import models.{MRN, UserAnswers}
+import models.{FileUploadAnswers, MRN}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito._
 import play.api.test.Helpers._
@@ -34,15 +34,15 @@ class MrnEntryControllerSpec extends ControllerSpecBase {
   private val mrnEntryPage = mock[mrn_entry]
   private val mrnAccessDeniedPage = mock[mrn_access_denied]
 
-  private val validAnswers = UserAnswers(eori, contactDetails = Some(contactDetails))
+  private val validAnswers = FileUploadAnswers(eori, contactDetails = Some(contactDetails))
 
-  private def mrnEntryController(answers: UserAnswers = validAnswers) =
+  private def mrnEntryController(answers: FileUploadAnswers = validAnswers) =
     new MrnEntryController(
       new FakeAuthAction(),
       new FakeDataRetrievalAction(Some(answers)),
       new FakeVerifiedEmailAction(),
       new MRNFormProvider,
-      mockAnswersConnector,
+      mockFileUploadAnswersService,
       mcc,
       mrnEntryPage,
       mrnDisValidator,
@@ -122,13 +122,13 @@ class MrnEntryControllerSpec extends ControllerSpecBase {
 
         val postRequest = fakeRequest.withFormUrlEncodedBody("value" -> mrn)
 
-        "call AnswersConnector" in {
+        "call AnswersService" in {
 
           when(mrnDisValidator.validate(any(), any())(any())).thenReturn(Future.successful(true))
 
           controller.onSubmit(postRequest).futureValue
 
-          val upsertedUserAnswers = theSavedUserAnswers
+          val upsertedUserAnswers = theSavedFileUploadAnswers
           upsertedUserAnswers.mrn mustBe defined
           upsertedUserAnswers.mrn.get mustBe MRN(mrn).get
         }
@@ -176,13 +176,13 @@ class MrnEntryControllerSpec extends ControllerSpecBase {
       }
 
       "passes MRN DIS validation" should {
-        "call AnswersConnector" in {
+        "call AnswersService" in {
 
           when(mrnDisValidator.validate(any(), any())(any())).thenReturn(Future.successful(true))
 
           controller.autoFill(mrn)(fakeRequest).futureValue
 
-          val upsertedUserAnswers = theSavedUserAnswers
+          val upsertedUserAnswers = theSavedFileUploadAnswers
           upsertedUserAnswers.mrn mustBe defined
           upsertedUserAnswers.mrn.get mustBe MRN(mrn).get
         }

--- a/test/controllers/SecureMessagingControllerSpec.scala
+++ b/test/controllers/SecureMessagingControllerSpec.scala
@@ -16,12 +16,10 @@
 
 package controllers
 
-import scala.concurrent.Future
-
 import base.TestRequests
 import connectors.SecureMessageFrontendConnector
-import models.exceptions.InvalidFeatureStateException
 import models.{ConversationPartial, InboxPartial, ReplyResultPartial}
+import models.exceptions.InvalidFeatureStateException
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{reset, verify, when}
 import play.api.i18n.Messages
@@ -31,6 +29,8 @@ import play.twirl.api.HtmlFormat
 import uk.gov.hmrc.http.HeaderCarrier
 import utils.FakeRequestCSRFSupport._
 import views.html.messaging.{inbox_wrapper, partial_wrapper}
+
+import scala.concurrent.Future
 
 class SecureMessagingControllerSpec extends ControllerSpecBase with TestRequests {
 
@@ -44,6 +44,7 @@ class SecureMessagingControllerSpec extends ControllerSpecBase with TestRequests
       new FakeAuthAction(),
       new FakeVerifiedEmailAction(),
       secureMessagingFeatureAction,
+      new FakeMessageFilterAction(),
       connector,
       mcc,
       partialWrapperPage,
@@ -80,7 +81,7 @@ class SecureMessagingControllerSpec extends ControllerSpecBase with TestRequests
 
           "wrap the partial in the inbox display wrapper" in {
             secureMessagingFeatureAction.enableSecureMessagingFeature()
-            when(connector.retrieveInboxPartial()(any[HeaderCarrier])).thenReturn(Future.successful(InboxPartial("")))
+            when(connector.retrieveInboxPartial(any(), any())(any[HeaderCarrier])).thenReturn(Future.successful(InboxPartial("")))
 
             val result = controller.displayInbox()(fakeRequest)
 
@@ -93,7 +94,7 @@ class SecureMessagingControllerSpec extends ControllerSpecBase with TestRequests
           "display the 'Sorry' page to the user" in {
             secureMessagingFeatureAction.enableSecureMessagingFeature()
 
-            when(connector.retrieveInboxPartial()(any[HeaderCarrier])).thenReturn(Future.failed(new Exception("Whoopse")))
+            when(connector.retrieveInboxPartial(any(), any())(any[HeaderCarrier])).thenReturn(Future.failed(new Exception("Whoopse")))
 
             an[Exception] mustBe thrownBy {
               await(controller.displayInbox()(fakeRequest))

--- a/test/controllers/UploadYourFilesReceiptControllerSpec.scala
+++ b/test/controllers/UploadYourFilesReceiptControllerSpec.scala
@@ -43,7 +43,7 @@ class UploadYourFilesReceiptControllerSpec extends ControllerSpecBase with SfusM
     sfusMetrics,
     originalConfirmationPage,
     secureMessagingConfirmationPage,
-    mockAnswersConnector,
+    mockFileUploadAnswersService,
     secureMessageConfig
   )(mcc, executionContext)
 
@@ -91,7 +91,7 @@ class UploadYourFilesReceiptControllerSpec extends ControllerSpecBase with SfusM
 
     "redirect to start page" when {
       "no user answers are in the cache" in {
-        when(mockAnswersConnector.findByEori(anyString()))
+        when(mockFileUploadAnswersService.findByEori(anyString()))
           .thenReturn(Future.successful(None))
 
         val result = controller.onPageLoad()(fakeRequest).futureValue
@@ -112,7 +112,7 @@ class UploadYourFilesReceiptControllerSpec extends ControllerSpecBase with SfusM
 
             result.header.status mustBe OK
 
-            verify(mockAnswersConnector).removeByEori(any())
+            verify(mockFileUploadAnswersService).removeByEori(any())
           }
         }
       }
@@ -127,19 +127,19 @@ class UploadYourFilesReceiptControllerSpec extends ControllerSpecBase with SfusM
             val result = controller.onPageLoad()(fakeRequest)
 
             status(result) mustBe OK
-            verify(mockAnswersConnector).removeByEori(any())
+            verify(mockFileUploadAnswersService).removeByEori(any())
           }
         }
       }
 
       "user is redirect to start page" in {
-        when(mockAnswersConnector.findByEori(anyString()))
+        when(mockFileUploadAnswersService.findByEori(anyString()))
           .thenReturn(Future.successful(None))
 
         val result = controller.onPageLoad()(fakeRequest).futureValue
 
         result.header.status mustBe SEE_OTHER
-        verify(mockAnswersConnector).removeByEori(any())
+        verify(mockFileUploadAnswersService).removeByEori(any())
       }
     }
   }
@@ -148,8 +148,8 @@ class UploadYourFilesReceiptControllerSpec extends ControllerSpecBase with SfusM
     when(cdsFileUploadConnector.getNotification(any())(any()))
       .thenReturn(Future.successful(Option(Notification(sampleFileUpload.reference, "SUCCESS", "someFile.pdf"))))
 
-    val answers = UserAnswers(eori, fileUploadResponse = Some(sampleFileUploadResponse))
-    when(mockAnswersConnector.findByEori(anyString()))
+    val answers = FileUploadAnswers(eori, fileUploadResponse = Some(sampleFileUploadResponse))
+    when(mockFileUploadAnswersService.findByEori(anyString()))
       .thenReturn(Future.successful(Some(answers)))
 
     test

--- a/test/controllers/actions/DataRetrievalActionSpec.scala
+++ b/test/controllers/actions/DataRetrievalActionSpec.scala
@@ -17,31 +17,31 @@
 package controllers.actions
 
 import controllers.ControllerSpecBase
-import models.UserAnswers
+import models.FileUploadAnswers
 import models.requests.{AuthenticatedRequest, DataRequest, VerifiedEmailRequest}
 import org.mockito.ArgumentMatchers.{eq => eqTo}
 import org.mockito.Mockito._
-import services.AnswersService
+import services.FileUploadAnswersService
 import testdata.CommonTestData._
 
 import scala.concurrent.Future
 
 class DataRetrievalActionSpec extends ControllerSpecBase {
 
-  private val answersConnector: AnswersService = mock[AnswersService]
-  private val action: ActionTestWrapper = new ActionTestWrapper(answersConnector)
+  private val answersService: FileUploadAnswersService = mock[FileUploadAnswersService]
+  private val action: ActionTestWrapper = new ActionTestWrapper(answersService)
 
-  private val answers = UserAnswers(eori)
+  private val answers = FileUploadAnswers(eori)
 
   override def beforeEach(): Unit = {
     super.beforeEach()
 
-    reset(answersConnector)
-    when(answersConnector.findOrCreate(eqTo(eori))) thenReturn Future.successful(answers)
+    reset(answersService)
+    when(answersService.findOrCreate(eqTo(eori))) thenReturn Future.successful(answers)
   }
 
   override def afterEach(): Unit = {
-    reset(answersConnector)
+    reset(answersService)
     super.afterEach()
   }
 
@@ -58,7 +58,7 @@ class DataRetrievalActionSpec extends ControllerSpecBase {
     }
   }
 
-  class ActionTestWrapper(answersConnector: AnswersService) extends DataRetrievalActionImpl(answersConnector, mcc) {
+  class ActionTestWrapper(answersService: FileUploadAnswersService) extends DataRetrievalActionImpl(answersService, mcc) {
     def callTransform[A](request: VerifiedEmailRequest[A]): Future[DataRequest[A]] = transform(request)
   }
 }

--- a/test/controllers/actions/FakeActions.scala
+++ b/test/controllers/actions/FakeActions.scala
@@ -18,7 +18,7 @@ package controllers.actions
 
 import config.SecureMessagingConfig
 import generators.Generators
-import models.{ContactDetails, MRN, UserAnswers}
+import models.{ContactDetails, ExportMessages, FileUploadAnswers, MRN, MessageFilterTag, SecureMessageAnswers}
 import models.requests._
 import org.mockito.Mockito
 import org.scalacheck.Arbitrary._
@@ -38,11 +38,11 @@ trait FakeActions extends Generators with MockitoSugar {
       Future.successful(Right(AuthenticatedRequest(request, user)))
   }
 
-  class FakeDataRetrievalAction(answers: Option[UserAnswers] = None) extends DataRetrievalAction {
+  class FakeDataRetrievalAction(answers: Option[FileUploadAnswers] = None) extends DataRetrievalAction {
     protected def executionContext = ExecutionContext.global
     def parser = stubBodyParser()
     override protected def transform[A](request: VerifiedEmailRequest[A]): Future[DataRequest[A]] =
-      Future.successful(DataRequest(request, answers.getOrElse(UserAnswers(request.eori))))
+      Future.successful(DataRequest(request, answers.getOrElse(FileUploadAnswers(request.eori))))
   }
 
   class FakeContactDetailsRequiredAction(val contactDetails: ContactDetails = arbitraryContactDetails.arbitrary.sample.get)
@@ -64,6 +64,13 @@ trait FakeActions extends Generators with MockitoSugar {
     def parser = stubBodyParser()
     override protected def refine[A](request: AuthenticatedRequest[A]): Future[Either[Result, VerifiedEmailRequest[A]]] =
       Future.successful(Right(VerifiedEmailRequest[A](request, email)))
+  }
+
+  class FakeMessageFilterAction(eori: String = eoriString.sample.get, tag: MessageFilterTag = ExportMessages) extends MessageFilterAction {
+    protected def executionContext = ExecutionContext.global
+    def parser = stubBodyParser()
+    override protected def refine[A](request: VerifiedEmailRequest[A]): Future[Either[Result, MessageFilterRequest[A]]] =
+      Future.successful(Right(MessageFilterRequest[A](request, SecureMessageAnswers(eori, tag))))
   }
 
   class SecureMessagingFeatureActionMock(private val secureMessagingConfig: SecureMessagingConfig = mock[SecureMessagingConfig])

--- a/test/controllers/actions/MessageFilterActionSpec.scala
+++ b/test/controllers/actions/MessageFilterActionSpec.scala
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.actions
+
+import controllers.Assets.Redirect
+import controllers.{routes, ControllerSpecBase}
+import models.{ExportMessages, SecureMessageAnswers}
+import models.requests.{AuthenticatedRequest, MessageFilterRequest, VerifiedEmailRequest}
+import org.mockito.ArgumentMatchers.{eq => eqTo}
+import org.mockito.Mockito._
+import play.api.mvc.Result
+import services.SecureMessageAnswersService
+import testdata.CommonTestData._
+
+import scala.concurrent.Future
+
+class MessageFilterActionSpec extends ControllerSpecBase {
+
+  private val answersService: SecureMessageAnswersService = mock[SecureMessageAnswersService]
+  private val action: ActionTestWrapper = new ActionTestWrapper(answersService)
+
+  private val answers = SecureMessageAnswers(eori, ExportMessages)
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+
+    reset(answersService)
+  }
+
+  override def afterEach(): Unit = {
+    reset(answersService)
+    super.afterEach()
+  }
+
+  "MessageFilterAction" when {
+    "the repository finds the user's filter selection" must {
+      "build a SecureMessageAnswers object and add it to the MessageFilterRequest" in {
+        when(answersService.findByEori(eqTo(eori))) thenReturn Future.successful(Some(answers))
+        val request = VerifiedEmailRequest(AuthenticatedRequest(fakeRequest, signedInUser), verifiedEmail)
+
+        val result = action.callRefine(request).futureValue
+
+        result.isRight mustBe true
+        result.right.get.secureMessageAnswers mustBe answers
+      }
+    }
+
+    "the repository does not find the user's filter selection" must {
+      "redirect the user to the message filter choice page" in {
+        when(answersService.findByEori(eqTo(eori_2))) thenReturn Future.successful(None)
+        val request = VerifiedEmailRequest(AuthenticatedRequest(fakeRequest, signedInUser.copy(eori = eori_2)), verifiedEmail)
+
+        val result = action.callRefine(request).futureValue
+
+        result.isLeft mustBe true
+        result.left.get mustBe Redirect(routes.InboxChoiceController.onPageLoad())
+      }
+    }
+  }
+
+  class ActionTestWrapper(answersService: SecureMessageAnswersService) extends MessageFilterActionImpl(answersService, mcc) {
+    def callRefine[A](request: VerifiedEmailRequest[A]): Future[Either[Result, MessageFilterRequest[A]]] = refine(request)
+  }
+}

--- a/test/models/MessageFilterTagSpec.scala
+++ b/test/models/MessageFilterTagSpec.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+import base.SpecBase
+
+class MessageFilterTagSpec extends SpecBase {
+
+  "MessageFilterTag valueOf" should {
+    "return the ExportMessages object when passed the correct string value representation" in {
+      MessageFilterTag.valueOf("ExportMessages") mustBe Some(ExportMessages)
+    }
+
+    "return the ImportMessages object when passed the correct string value representation" in {
+      MessageFilterTag.valueOf("ImportMessages") mustBe Some(ImportMessages)
+    }
+
+    "return nothing when passed an incorrect string value representation" in {
+      MessageFilterTag.valueOf("Imports") mustBe None
+    }
+  }
+}


### PR DESCRIPTION
Save the user's filter selection in a new mongo collection
and check that the user has made a selection when visiting
the inbox and conversation pages. If user has not made a
selection then redirect the user to the filter choice page