### PR TITLE
CEDS-3027 Fix the "Back" link on the "MRN Entry" page

### DIFF
--- a/app/controllers/MrnEntryController.scala
+++ b/app/controllers/MrnEntryController.scala
@@ -16,7 +16,12 @@
 
 package controllers
 
+import javax.inject.Inject
+
+import scala.concurrent.{ExecutionContext, Future}
+
 import com.google.inject.Singleton
+import config.SecureMessagingConfig
 import controllers.actions._
 import forms.MRNFormProvider
 import models.{EORI, MRN}
@@ -28,9 +33,6 @@ import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import views.html.{mrn_access_denied, mrn_entry}
 
-import javax.inject.Inject
-import scala.concurrent.{ExecutionContext, Future}
-
 @Singleton
 class MrnEntryController @Inject()(
   authenticate: AuthAction,
@@ -41,21 +43,26 @@ class MrnEntryController @Inject()(
   mcc: MessagesControllerComponents,
   mrnEntry: mrn_entry,
   mrnDisValidator: MrnDisValidator,
-  mrnAccessDenied: mrn_access_denied
+  mrnAccessDenied: mrn_access_denied,
+  secureMessagingConfig: SecureMessagingConfig
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport {
 
   val form = formProvider()
 
+  val backLinkUrl =
+    if (secureMessagingConfig.isSecureMessagingEnabled) routes.ChoiceController.onPageLoad.url
+    else routes.StartController.displayStartPage.url
+
   def onPageLoad: Action[AnyContent] = (authenticate andThen verifiedEmail andThen getData) { implicit req =>
     val populatedForm = req.userAnswers.mrn.fold(form)(form.fill)
-    Ok(mrnEntry(populatedForm))
+    Ok(mrnEntry(populatedForm, backLinkUrl))
   }
 
   def onSubmit: Action[AnyContent] = (authenticate andThen verifiedEmail andThen getData).async { implicit req =>
     form
       .bindFromRequest()
-      .fold(errorForm => Future.successful(BadRequest(mrnEntry(errorForm))), mrn => checkMrnExistenceAndOwnership(mrn))
+      .fold(errorForm => Future.successful(BadRequest(mrnEntry(errorForm, backLinkUrl))), mrn => checkMrnExistenceAndOwnership(mrn))
   }
 
   def autoFill(mrn: String): Action[AnyContent] = (authenticate andThen verifiedEmail andThen getData).async { implicit req =>
@@ -73,6 +80,6 @@ class MrnEntryController @Inject()(
         }
     }
 
-  private def invalidMrnResponse(mrn: String)(implicit req: DataRequest[AnyContent]) =
+  private def invalidMrnResponse(mrn: String)(implicit req: DataRequest[AnyContent]): Future[Result] =
     Future.successful(BadRequest(mrnAccessDenied(mrn)))
 }

--- a/app/views/mrn_entry.scala.html
+++ b/app/views/mrn_entry.scala.html
@@ -17,19 +17,26 @@
 @import uk.gov.hmrc.govukfrontend.views.html.components._
 @import views.html.components.gds._
 @import views.Title
+@import config.SecureMessagingConfig
 
 @this(
-        mainTemplate: gdsMainTemplate,
-        errorSummary: errorSummary,
-        formHelper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF,
-        exportsInputText: exportsInputText,
-        govukButton: GovukButton,
-        pageTitle: pageTitle
+    mainTemplate: gdsMainTemplate,
+    errorSummary: errorSummary,
+    formHelper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF,
+    exportsInputText: exportsInputText,
+    govukButton: GovukButton,
+    pageTitle: pageTitle,
+    secureMessagingConfig: SecureMessagingConfig
 )
 
 @(form: Form[MRN])(implicit request: Request[_], messages: Messages)
 
-@mainTemplate(title = Title("mrnEntryPage.heading"), backLinkUrl = Some(routes.ChoiceController.onPageLoad.url)) {
+@backLinkUrl = @{
+  if (secureMessagingConfig.isSecureMessagingEnabled) routes.ChoiceController.onPageLoad.url
+  else routes.StartController.displayStartPage.url
+}
+
+@mainTemplate(title = Title("mrnEntryPage.heading"), backLinkUrl = Some(backLinkUrl)) {
 
 <div class="form-group">
     <div class="govuk-grid-row">

--- a/app/views/mrn_entry.scala.html
+++ b/app/views/mrn_entry.scala.html
@@ -17,7 +17,6 @@
 @import uk.gov.hmrc.govukfrontend.views.html.components._
 @import views.html.components.gds._
 @import views.Title
-@import config.SecureMessagingConfig
 
 @this(
     mainTemplate: gdsMainTemplate,
@@ -25,16 +24,10 @@
     formHelper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF,
     exportsInputText: exportsInputText,
     govukButton: GovukButton,
-    pageTitle: pageTitle,
-    secureMessagingConfig: SecureMessagingConfig
+    pageTitle: pageTitle
 )
 
-@(form: Form[MRN])(implicit request: Request[_], messages: Messages)
-
-@backLinkUrl = @{
-  if (secureMessagingConfig.isSecureMessagingEnabled) routes.ChoiceController.onPageLoad.url
-  else routes.StartController.displayStartPage.url
-}
+@(form: Form[MRN], backLinkUrl: String)(implicit request: Request[_], messages: Messages)
 
 @mainTemplate(title = Title("mrnEntryPage.heading"), backLinkUrl = Some(backLinkUrl)) {
 

--- a/test/controllers/MrnEntryControllerSpec.scala
+++ b/test/controllers/MrnEntryControllerSpec.scala
@@ -16,6 +16,9 @@
 
 package controllers
 
+import scala.concurrent.Future
+
+import config.SecureMessagingConfig
 import forms.MRNFormProvider
 import models.{FileUploadAnswers, MRN}
 import org.mockito.ArgumentMatchers.any
@@ -26,13 +29,12 @@ import services.MrnDisValidator
 import testdata.CommonTestData._
 import views.html.{mrn_access_denied, mrn_entry}
 
-import scala.concurrent.Future
-
 class MrnEntryControllerSpec extends ControllerSpecBase {
 
   private val mrnDisValidator = mock[MrnDisValidator]
   private val mrnEntryPage = mock[mrn_entry]
   private val mrnAccessDeniedPage = mock[mrn_access_denied]
+  private val secureMessagingConfig = mock[SecureMessagingConfig]
 
   private val validAnswers = FileUploadAnswers(eori, contactDetails = Some(contactDetails))
 
@@ -46,21 +48,17 @@ class MrnEntryControllerSpec extends ControllerSpecBase {
       mcc,
       mrnEntryPage,
       mrnDisValidator,
-      mrnAccessDeniedPage
+      mrnAccessDeniedPage,
+      secureMessagingConfig
     )(executionContext)
 
   override def beforeEach(): Unit = {
     super.beforeEach()
 
-    reset(mrnEntryPage, mrnAccessDeniedPage, mrnDisValidator)
-    when(mrnEntryPage.apply(any())(any(), any())).thenReturn(HtmlFormat.empty)
+    reset(mrnEntryPage, mrnAccessDeniedPage, mrnDisValidator, secureMessagingConfig)
+    when(mrnEntryPage.apply(any(), any())(any(), any())).thenReturn(HtmlFormat.empty)
     when(mrnAccessDeniedPage.apply(any())(any(), any())).thenReturn(HtmlFormat.empty)
-  }
-
-  override def afterEach(): Unit = {
-    reset(mrnEntryPage, mrnAccessDeniedPage, mrnDisValidator)
-
-    super.afterEach()
+    when(secureMessagingConfig.isSecureMessagingEnabled).thenReturn(true)
   }
 
   "MrnEntryController on onPageLoad" should {


### PR DESCRIPTION
Fix the landing page when clicking the "Back" link on the "MRN Entry" page.
- Secure Messaging flag **disabled** => "Start" page
- Secure Messaging flag **enabled** => "Choice" page