### PR TITLE
[CEDS-3098] Custom back button redirect on mrn page

### DIFF
--- a/app/controllers/ChoiceController.scala
+++ b/app/controllers/ChoiceController.scala
@@ -49,7 +49,7 @@ class ChoiceController @Inject()(
         validChoice =>
           validChoice.choice match {
             case SecureMessageInbox => Redirect(controllers.routes.InboxChoiceController.onPageLoad)
-            case DocumentUpload     => Redirect(controllers.routes.MrnEntryController.onPageLoad)
+            case DocumentUpload     => Redirect(controllers.routes.MrnEntryController.onPageLoad())
         }
       )
   }

--- a/app/controllers/MrnEntryController.scala
+++ b/app/controllers/MrnEntryController.scala
@@ -16,22 +16,23 @@
 
 package controllers
 
-import javax.inject.Inject
-
-import scala.concurrent.{ExecutionContext, Future}
-
 import com.google.inject.Singleton
 import config.SecureMessagingConfig
 import controllers.actions._
 import forms.MRNFormProvider
-import models.{EORI, MRN}
+import models.{EORI, FileUploadAnswers, MRN}
 import models.requests.DataRequest
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents, Result}
 import services.{FileUploadAnswersService, MrnDisValidator}
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
+
+import javax.inject.Inject
+import scala.concurrent.{ExecutionContext, Future}
 import views.html.{mrn_access_denied, mrn_entry}
+
+import java.net.URLDecoder.decode
 
 @Singleton
 class MrnEntryController @Inject()(
@@ -50,36 +51,56 @@ class MrnEntryController @Inject()(
 
   val form = formProvider()
 
-  lazy val backLinkUrl: String =
+  lazy val defautBackLinkUrl: String =
     if (secureMessagingConfig.isSecureMessagingEnabled) routes.ChoiceController.onPageLoad.url
     else routes.StartController.displayStartPage.url
 
-  def onPageLoad: Action[AnyContent] = (authenticate andThen verifiedEmail andThen getData) { implicit req =>
+  private def getBackLink(refererUrl: Option[String]) = refererUrl.getOrElse(defautBackLinkUrl)
+
+  def onPageLoad(refererUrl: Option[String] = None): Action[AnyContent] = (authenticate andThen verifiedEmail andThen getData).async { implicit req =>
     val populatedForm = req.userAnswers.mrn.fold(form)(form.fill)
-    Ok(mrnEntry(populatedForm, backLinkUrl))
+
+    decodeRefererUrl(refererUrl).map { decodedBackLink =>
+      answersService
+        .upsert(req.userAnswers.copy(mrnPageRefererUrl = Some(decodedBackLink)))
+        .map(_ => Ok(mrnEntry(populatedForm, getBackLink(Some(decodedBackLink)))))
+    }.getOrElse(Future.successful(Ok(mrnEntry(populatedForm, getBackLink(req.userAnswers.mrnPageRefererUrl)))))
   }
 
   def onSubmit: Action[AnyContent] = (authenticate andThen verifiedEmail andThen getData).async { implicit req =>
     form
       .bindFromRequest()
-      .fold(errorForm => Future.successful(BadRequest(mrnEntry(errorForm, backLinkUrl))), mrn => checkMrnExistenceAndOwnership(mrn))
+      .fold(
+        errorForm => Future.successful(BadRequest(mrnEntry(errorForm, getBackLink(req.userAnswers.mrnPageRefererUrl)))),
+        mrn => checkMrnExistenceAndOwnership(mrn, req.userAnswers)
+      )
   }
 
-  def autoFill(mrn: String): Action[AnyContent] = (authenticate andThen verifiedEmail andThen getData).async { implicit req =>
-    MRN(mrn)
-      .map(checkMrnExistenceAndOwnership(_))
-      .getOrElse(invalidMrnResponse(mrn))
+  def autoFill(mrn: String, refererUrl: Option[String] = None): Action[AnyContent] = (authenticate andThen verifiedEmail andThen getData).async {
+    implicit req =>
+      val updatedAnswers = decodeRefererUrl(refererUrl)
+        .map(decodedBackLink => req.userAnswers.copy(mrnPageRefererUrl = Some(decodedBackLink)))
+        .getOrElse(req.userAnswers)
+
+      MRN(mrn)
+        .map(checkMrnExistenceAndOwnership(_, updatedAnswers))
+        .getOrElse(invalidMrnResponse(mrn))
   }
 
-  private def checkMrnExistenceAndOwnership(mrn: MRN)(implicit hc: HeaderCarrier, req: DataRequest[AnyContent]): Future[Result] =
+  private def checkMrnExistenceAndOwnership(
+    mrn: MRN,
+    userAnswers: FileUploadAnswers
+  )(implicit hc: HeaderCarrier, req: DataRequest[AnyContent]): Future[Result] =
     mrnDisValidator.validate(mrn, EORI(req.request.eori)).flatMap {
       case false => invalidMrnResponse(mrn.value)
       case true =>
-        answersService.upsert(req.userAnswers.copy(mrn = Some(mrn))).map { _ =>
+        answersService.upsert(userAnswers.copy(mrn = Some(mrn))).map { _ =>
           Redirect(routes.ContactDetailsController.onPageLoad())
         }
     }
 
   private def invalidMrnResponse(mrn: String)(implicit req: DataRequest[AnyContent]): Future[Result] =
     Future.successful(BadRequest(mrnAccessDenied(mrn)))
+
+  private val decodeRefererUrl = (refererUrl: Option[String]) => refererUrl.map(url => decode(url, "UTF-8"))
 }

--- a/app/models/FileUploadAnswers.scala
+++ b/app/models/FileUploadAnswers.scala
@@ -26,7 +26,8 @@ case class FileUploadAnswers(
   contactDetails: Option[ContactDetails] = None,
   fileUploadCount: Option[FileUploadCount] = None,
   fileUploadResponse: Option[FileUploadResponse] = None,
-  updated: DateTime = DateTime.now.withZone(DateTimeZone.UTC)
+  updated: DateTime = DateTime.now.withZone(DateTimeZone.UTC),
+  mrnPageRefererUrl: Option[String] = None
 )
 
 object FileUploadAnswers {

--- a/app/views/components/gds/navigationBanner.scala.html
+++ b/app/views/components/gds/navigationBanner.scala.html
@@ -22,6 +22,6 @@
 
 <div id="navigation-banner" class="govuk-!-padding-bottom-3 govuk-!-padding-top-3">
   @link(text = messages("common.navigation.messages"), call = routes.InboxChoiceController.onPageLoad, classes="govuk-link govuk-link--no-visited-state right-margin--30")
-  @link(text = messages("common.navigation.uploadFiles"), call = routes.MrnEntryController.onPageLoad)
+  @link(text = messages("common.navigation.uploadFiles"), call = routes.MrnEntryController.onPageLoad())
 </div>
 <hr class="govuk-section-break govuk-section-break--visible">

--- a/app/views/contact_details.scala.html
+++ b/app/views/contact_details.scala.html
@@ -30,7 +30,7 @@
 
 @(form: Form[ContactDetails], mrn: MRN)(implicit request: Request[_], messages: Messages)
 
-@mainTemplate(title = Title("contactDetails.heading"), backLinkUrl = Some(routes.MrnEntryController.onPageLoad.url)) {
+@mainTemplate(title = Title("contactDetails.heading"), backLinkUrl = Some(routes.MrnEntryController.onPageLoad().url)) {
 
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">

--- a/app/views/messaging/partial_wrapper.scala.html
+++ b/app/views/messaging/partial_wrapper.scala.html
@@ -21,7 +21,7 @@
 
 @this(mainTemplate: gdsMainTemplate, govukAccordion : GovukAccordion, govukBackLink : GovukBackLink)
 
-@(partial: HtmlFormat.Appendable, titleKey: String, backLinkUrl: Option[String] = None)(implicit request: Request[_], messages: Messages)
+@(partial: HtmlFormat.Appendable, titleKey: String, uploadLink: String, backLinkUrl: Option[String] = None)(implicit request: Request[_], messages: Messages)
 
 @mainTemplate(
   title = Title(titleKey),
@@ -42,7 +42,7 @@
         <p class="govuk-body">@messages("greyBox.paragraph.1")</p>
         <p class="govuk-body">@messages("greyBox.paragraph.2")</p>
 
-        <a class="govuk-link govuk-link--no-visited-state" href="@routes.MrnEntryController.onPageLoad">
+        <a class="govuk-link govuk-link--no-visited-state" href="@uploadLink">
           @messages("greyBox.uploadFiles")
         </a>
       </div>

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -25,9 +25,9 @@ GET         /conversation/:client/:conversationId           controllers.SecureMe
 POST        /conversation/:client/:conversationId           controllers.SecureMessagingController.submitReply(client, conversationId)
 GET         /conversation/:client/:conversationId/result    controllers.SecureMessagingController.displayReplyResult(client, conversationId)
 
-GET         /mrn-entry                                      controllers.MrnEntryController.onPageLoad
+GET         /mrn-entry                                      controllers.MrnEntryController.onPageLoad(refererUrl: Option[String] ?= None)
 POST        /mrn-entry                                      controllers.MrnEntryController.onSubmit
-GET         /mrn-entry/:mrn                                 controllers.MrnEntryController.autoFill(mrn)
+GET         /mrn-entry/:mrn                                 controllers.MrnEntryController.autoFill(mrn, refererUrl: Option[String] ?= None)
 
 GET         /contact-details                                controllers.ContactDetailsController.onPageLoad
 POST        /contact-details                                controllers.ContactDetailsController.onSubmit

--- a/test/controllers/SecureMessagingControllerSpec.scala
+++ b/test/controllers/SecureMessagingControllerSpec.scala
@@ -58,7 +58,7 @@ class SecureMessagingControllerSpec extends ControllerSpecBase with TestRequests
     secureMessagingFeatureAction.reset()
 
     when(partialWrapperPage.apply(any[HtmlFormat.Appendable])(any[Request[_]], any[Messages])).thenReturn(HtmlFormat.empty)
-    when(partial_wrapper.apply(any[HtmlFormat.Appendable], any[String], any[Option[String]])(any[Request[_]], any[Messages]))
+    when(partial_wrapper.apply(any[HtmlFormat.Appendable], any[String], any[String], any[Option[String]])(any[Request[_]], any[Messages]))
       .thenReturn(HtmlFormat.empty)
   }
 

--- a/test/views/ContactDetailsSpec.scala
+++ b/test/views/ContactDetailsSpec.scala
@@ -55,7 +55,7 @@ class ContactDetailsSpec extends DomAssertions with ViewBehaviours with ScalaChe
     }
 
     "display the 'Back' link" in {
-      assertBackLinkIsIncluded(asDocument(view), routes.MrnEntryController.onPageLoad.url)
+      assertBackLinkIsIncluded(asDocument(view), routes.MrnEntryController.onPageLoad().url)
     }
 
     "display name input" in {

--- a/test/views/UploadYourFilesSpec.scala
+++ b/test/views/UploadYourFilesSpec.scala
@@ -16,7 +16,6 @@
 
 package views
 
-import controllers.routes
 import generators.Generators
 import models._
 import models.requests.{AuthenticatedRequest, SignedInUser}

--- a/test/views/messaging/PartialWrapperSpec.scala
+++ b/test/views/messaging/PartialWrapperSpec.scala
@@ -98,12 +98,12 @@ class PartialWrapperSpec extends DomAssertions with ViewMatchers {
   private def assertUploadFilesLink(view: Document): Assertion = {
     val elements: List[Element] = view.getElementsByClass("govuk-link").iterator.asScala.toList
     assert(elements.exists { element =>
-      element.text == messages("greyBox.uploadFiles") && element.attr("href") == routes.MrnEntryController.onPageLoad.url
+      element.text == messages("greyBox.uploadFiles") && element.attr("href") == routes.MrnEntryController.onPageLoad().url
     })
   }
 
   private def genView(titleKey: String, backLinkUrl: Option[String]): Document = {
     when(secureMessagingConfig.isSecureMessagingEnabled).thenReturn(true)
-    partialWrapperPage(HtmlFormat.raw(partialContent), titleKey, backLinkUrl)(fakeRequest, messages)
+    partialWrapperPage(HtmlFormat.raw(partialContent), titleKey, routes.MrnEntryController.onPageLoad().url, backLinkUrl)(fakeRequest, messages)
   }
 }


### PR DESCRIPTION
Added a new query string parameter of refererUrl to the
two GET mrn_entry endpoints. If passed this refererUrl
is saved in cache and used to populate the backUrl
value of the mrn_entry page.

Added this query string parameter to the link taking the 
user from the message page to the mrn_entry page.