### PR TITLE
[CEDS-2946] Fix highlighting of form field error link

### DIFF
--- a/app/views/choice_page.scala.html
+++ b/app/views/choice_page.scala.html
@@ -20,8 +20,8 @@
 @import uk.gov.hmrc.govukfrontend.views.html.components._
 @import views.html.components.gds._
 @import views.Title
+@import views.helpers.ErrorMapper.radioGroupErrors
 @import views.components.gds.Styles._
-
 
 @this(
   mainTemplate: gdsMainTemplate,
@@ -36,8 +36,7 @@
 @mainTemplate(title = Title("choicePage.heading")) {
 
   @formHelper(action = routes.ChoiceController.onSubmit(), 'autoComplete -> "off") {
-
-    @errorSummary(form.errors)
+    @errorSummary(radioGroupErrors("choice", SecureMessageInbox, form.errors))
 
     @govukRadios(Radios(
       name = ChoiceKey,

--- a/app/views/helpers/ErrorMapper.scala
+++ b/app/views/helpers/ErrorMapper.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views.helpers
+
+import play.api.data.FormError
+
+object ErrorMapper {
+
+  def eoriOrAddressErrors(groupKey: String, errors: Seq[FormError]) =
+    errors.map(err => err.copy(key = if (err.key == groupKey) s"$groupKey.eori" else err.key))
+
+  def radioGroupErrors(groupKey: String, firstOption: String, errors: Seq[FormError]) =
+    errors.map(err => err.copy(key = if (err.key == groupKey) firstOption else err.key))
+
+  def yesNoErrors(errors: Seq[FormError]): Seq[FormError] = radioGroupErrors("yesNo", "code_yes", errors)
+}

--- a/app/views/messaging/inbox_choice.scala.html
+++ b/app/views/messaging/inbox_choice.scala.html
@@ -19,9 +19,9 @@
 @import forms.InboxChoiceForm.Values.{ExportsMessages, ImportsMessages}
 @import uk.gov.hmrc.govukfrontend.views.html.components._
 @import views.components.gds.Styles._
+@import views.helpers.ErrorMapper.radioGroupErrors
 @import views.html.components.gds._
 @import views.Title
-
 
 @this(
   mainTemplate: gdsMainTemplate,
@@ -36,8 +36,7 @@
 @mainTemplate(title = Title("inboxChoice.heading"), backLinkUrl = Some(routes.ChoiceController.onPageLoad.url)) {
 
   @formHelper(action = routes.InboxChoiceController.onSubmit, 'autoComplete -> "off") {
-
-    @errorSummary(form.errors)
+    @errorSummary(radioGroupErrors("choice", ExportsMessages, form.errors))
 
     @govukRadios(Radios(
       name = InboxChoiceKey,

--- a/test/views/ChoicePageSpec.scala
+++ b/test/views/ChoicePageSpec.scala
@@ -17,7 +17,8 @@
 package views
 
 import forms.ChoiceForm
-import forms.ChoiceForm.AllowedChoiceValues
+import forms.ChoiceForm.AllowedChoiceValues._
+import forms.ChoiceForm.ChoiceKey
 import org.jsoup.nodes.Document
 import views.html.choice_page
 import views.matchers.ViewMatchers
@@ -29,8 +30,30 @@ class ChoicePageSpec extends DomAssertions with ViewMatchers {
 
   private val view: Document = choicePage(form)(fakeRequest, messages)
 
-  "Choice page" should {
+  "Choice page" when {
+    "form does not contain errors" should {
+      commonAssertions()
+    }
 
+    "form contains errors" should {
+      commonAssertions()
+
+      val errorView = choicePage(form.withError(ChoiceKey, "choicePage.input.error.empty"))(fakeRequest, messages)
+
+      "display error box at top of page" in {
+        errorView.getElementsByClass("govuk-error-summary__title").first() must containMessage("error.summary.title")
+      }
+
+      "display error box with a link to first radio option" in {
+        val errorLink = errorView.getElementsByClass("govuk-list govuk-error-summary__list").first().getElementsByTag("a").first()
+
+        errorLink must containMessage("choicePage.input.error.empty")
+        errorLink must haveHref(s"#${SecureMessageInbox}")
+      }
+    }
+  }
+
+  private def commonAssertions() = {
     "display page header" in {
       view.getElementsByTag("h1").first() must containMessage("choicePage.heading")
     }
@@ -40,8 +63,8 @@ class ChoicePageSpec extends DomAssertions with ViewMatchers {
     }
 
     "display radio buttons" in {
-      view must containElementWithID(AllowedChoiceValues.SecureMessageInbox)
-      view must containElementWithID(AllowedChoiceValues.DocumentUpload)
+      view must containElementWithID(SecureMessageInbox)
+      view must containElementWithID(DocumentUpload)
     }
 
     "display 'Continue' button" in {

--- a/test/views/messaging/InboxChoiceSpec.scala
+++ b/test/views/messaging/InboxChoiceSpec.scala
@@ -18,7 +18,8 @@ package views.messaging
 
 import controllers.routes
 import forms.InboxChoiceForm
-import forms.InboxChoiceForm.Values
+import forms.InboxChoiceForm.{InboxChoiceKey, Values}
+import forms.InboxChoiceForm.Values.ExportsMessages
 import org.jsoup.nodes.Document
 import views.DomAssertions
 import views.html.messaging.inbox_choice
@@ -31,8 +32,31 @@ class InboxChoiceSpec extends DomAssertions with ViewMatchers {
 
   private val view: Document = inboxChoice(form)(fakeRequest, messages)
 
-  "The Message Inbox Choice page" should {
+  "The Message Inbox Choice page" when {
+    "form does not contain errors" should {
+      commonAssertions()
+    }
 
+    "form contains errors" should {
+      commonAssertions()
+
+      val errorView = inboxChoice(form.withError(InboxChoiceKey, "choicePage.input.error.empty"))(fakeRequest, messages)
+
+      "display error box at top of page" in {
+        errorView.getElementsByClass("govuk-error-summary__title").first() must containMessage("error.summary.title")
+      }
+
+      "display error box with a link to first radio option" in {
+        val errorLink = errorView.getElementsByClass("govuk-list govuk-error-summary__list").first().getElementsByTag("a").first()
+
+        errorLink must containMessage("choicePage.input.error.empty")
+        errorLink must haveHref(s"#${ExportsMessages}")
+      }
+    }
+
+  }
+
+  private def commonAssertions() = {
     "display page header" in {
       view.getElementsByTag("h1").first() must containMessage("inboxChoice.heading")
     }
@@ -50,5 +74,4 @@ class InboxChoiceSpec extends DomAssertions with ViewMatchers {
       view.getElementsByClass("govuk-button").first() must containMessage("common.continue")
     }
   }
-
 }


### PR DESCRIPTION
When the user fails to select an option in a radio
button form field, the error box displayed at the top
of the page should contain a link that when clicked
takes the user to that particular form field.

The two new choice pages on SFUS contained this link
but it was not taking them to the form field (was not
highlighting the first radio option) due to the anchor
reference being wrong. This is now fixed