### PR TITLE
[CEDS-3161] Sanitise accepted referer URL parameter

### DIFF
--- a/app/utils/RefererUrlValidator.scala
+++ b/app/utils/RefererUrlValidator.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package utils
+
+import play.api.Configuration
+import javax.inject.Inject
+
+class RefererUrlValidator @Inject()(configuration: Configuration) {
+  lazy val allowedRefererServices = configuration.get[Seq[String]]("allowList.refererServices")
+
+  def isValid(refererUrl: String): Boolean =
+    refersToServiceOnAllowList(refererUrl) && onlyContainsAllowedCharacters(refererUrl)
+
+  private val charsNotAllowedPattern = "[^0-9A-Za-z/_-?=&]+".r //negated character class of allowed characters
+  private def onlyContainsAllowedCharacters(refererUrl: String): Boolean =
+    charsNotAllowedPattern.replaceAllIn(refererUrl, "").length == refererUrl.length
+
+  private def refersToServiceOnAllowList(refererUrl: String): Boolean = {
+    val urlNamespaceParts = refererUrl.split("/").toList
+    urlNamespaceParts match {
+      case first :: serviceName :: _ if (first.isEmpty) =>
+        allowedRefererServices.contains(serviceName)
+      case _ => false
+    }
+  }
+}

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -231,7 +231,10 @@ secure-message-answers-repository {
   ttl-seconds = 3600
 }
 
-allowList.eori = []
+allowList {
+  eori = []
+  refererServices = ["cds-file-upload-service", "customs-declare-exports"]
+}
 
 # Google Tag Manager (GTM) configuration
 tracking-consent-frontend {

--- a/test/utils/RefererUrlValidatorSpec.scala
+++ b/test/utils/RefererUrlValidatorSpec.scala
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package utils
+
+import base.Injector
+import com.typesafe.config.ConfigFactory
+import org.scalatestplus.play.PlaySpec
+import play.api.Configuration
+
+class RefererUrlValidatorSpec extends PlaySpec with Injector {
+
+  private val allowedService1 = "service1"
+  private val allowedService2 = "service2"
+  private val disallowedService3 = "service3"
+  private val validRefererUrl = s"/$allowedService1/"
+
+  lazy val config = Configuration(ConfigFactory.parseString(s"""
+       allowList.refererServices = ["$allowedService1", "$allowedService2"]
+    """))
+  val validator = new RefererUrlValidator(config)
+
+  "RefererUrlValidator" should {
+    "extract the referer services allowed from the config" in {
+      validator.allowedRefererServices.size mustBe 2
+
+      validator.allowedRefererServices must contain(allowedService1)
+      validator.allowedRefererServices must contain(allowedService2)
+    }
+
+    "allow referer urls that reference the services on the allow list" in {
+      validator.isValid(s"/$allowedService1/") mustBe true
+      validator.isValid(s"/$allowedService2/") mustBe true
+    }
+
+    "deny referer urls that reference the services not on the allow list" in {
+      validator.isValid(s"/$disallowedService3/") mustBe false
+      validator.isValid(s"/something$allowedService1/") mustBe false
+      validator.isValid(s"/something/$allowedService1/") mustBe false
+    }
+
+    "deny referer urls that do not start with a '/'" in {
+      validator.isValid(s"$allowedService1/") mustBe false
+    }
+
+    "deny referer urls that specify a host value" in {
+      validator.isValid(s"www.google.com/$allowedService1/") mustBe false
+    }
+
+    "deny referer urls that specify a protocol" in {
+      validator.isValid(s"javaScript:/$allowedService1/") mustBe false
+    }
+
+    "deny referer urls that contain prohibited ASCII characters" in {
+      val prohibitedChars = Seq('`', '¬', '\'', '!', '"', '£', '$', '%', '^', '*', '(', ')', '+', '[', ']', '{', '}', ';', ':', '@', '#',
+        '~', '<', '>', ',', '.', '\\')
+
+      prohibitedChars.foreach(
+        char =>
+          withClue(s"including char '${char}'") {
+            validator.isValid(s"${validRefererUrl}${char}") mustBe false
+        }
+      )
+    }
+
+    "allow referer urls that contain allowed non-alphanumeric ASCII characters" in {
+      val allowedChars = Seq('_', '-', '/', '?', '&', '=')
+
+      allowedChars.foreach(
+        char =>
+          withClue(s"including char '${char}'") {
+            validator.isValid(s"${validRefererUrl}${char}") mustBe true
+        }
+      )
+    }
+
+    "deny referer urls that contain extended characters" in {
+      val prohibitedChars = Seq('\u200B', '¥', 'ä')
+
+      prohibitedChars.foreach(
+        char =>
+          withClue(s"including char '${char}'") {
+            validator.isValid(s"${validRefererUrl}${char}") mustBe false
+        }
+      )
+    }
+  }
+}


### PR DESCRIPTION
To plug the security vulnerability that was picked up
in the pen test.

We now only allow relative urls that point to an
MDTP service that are on our allow list of services
and that only contain a limited set of ASCII chars.