### PR TITLE
[CEDS-3161] Sanitise accepted referer URL parameter

### DIFF
--- a/app/config/AppConfig.scala
+++ b/app/config/AppConfig.scala
@@ -32,7 +32,8 @@ case class AppConfig(
   fileUploadAnswersRepository: FileUploadAnswersRepository,
   secureMessageAnswersRepository: SecureMessageAnswersRepository,
   trackingConsentFrontend: TrackingConsentFrontend,
-  platform: Platform
+  platform: Platform,
+  allowList: AllowList
 )
 
 object AppConfig {
@@ -139,3 +140,5 @@ case class SecureMessaging(
   def submitReplyEndpoint(client: String, conversationId: String): String =
     s"${protocol.getOrElse("https")}://$host:${port.getOrElse(443)}$submitReply/$client/$conversationId"
 }
+
+case class AllowList(eori: List[String], refererServices: List[String])

--- a/app/controllers/MrnEntryController.scala
+++ b/app/controllers/MrnEntryController.scala
@@ -17,7 +17,7 @@
 package controllers
 
 import com.google.inject.Singleton
-import config.SecureMessagingConfig
+import config.{AppConfig, SecureMessagingConfig}
 import controllers.actions._
 import forms.MRNFormProvider
 import models.{EORI, FileUploadAnswers, MRN}
@@ -27,6 +27,7 @@ import play.api.mvc.{Action, AnyContent, MessagesControllerComponents, Result}
 import services.{FileUploadAnswersService, MrnDisValidator}
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
+import utils.RefererUrlValidator
 
 import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
@@ -46,7 +47,7 @@ class MrnEntryController @Inject()(
   mrnDisValidator: MrnDisValidator,
   mrnAccessDenied: mrn_access_denied,
   secureMessagingConfig: SecureMessagingConfig
-)(implicit ec: ExecutionContext)
+)(implicit ec: ExecutionContext, appConf: AppConfig)
     extends FrontendController(mcc) with I18nSupport {
 
   private val form = formProvider()
@@ -60,10 +61,15 @@ class MrnEntryController @Inject()(
   def onPageLoad(refererUrl: Option[String] = None): Action[AnyContent] = (authenticate andThen verifiedEmail andThen getData).async { implicit req =>
     val populatedForm = req.userAnswers.mrn.fold(form)(form.fill)
 
-    decodeRefererUrl(refererUrl).map { decodedBackLink =>
+    val sanitisedRefererUrl = for {
+      decodedUrl <- decodeRefererUrl(refererUrl)
+      filteredUrl <- filterBadRefererUrl(decodedUrl)
+    } yield filteredUrl
+
+    sanitisedRefererUrl.map { backLink =>
       answersService
-        .upsert(req.userAnswers.copy(mrnPageRefererUrl = Some(decodedBackLink)))
-        .map(_ => Ok(mrnEntry(populatedForm, getBackLink(Some(decodedBackLink)))))
+        .upsert(req.userAnswers.copy(mrnPageRefererUrl = Some(backLink)))
+        .map(_ => Ok(mrnEntry(populatedForm, getBackLink(Some(backLink)))))
     }.getOrElse(Future.successful(Ok(mrnEntry(populatedForm, getBackLink(req.userAnswers.mrnPageRefererUrl)))))
   }
 
@@ -103,4 +109,6 @@ class MrnEntryController @Inject()(
     Future.successful(BadRequest(mrnAccessDenied(mrn)))
 
   private val decodeRefererUrl = (refererUrl: Option[String]) => refererUrl.map(url => decode(url, "UTF-8"))
+
+  private val filterBadRefererUrl = (refererUrl: String) => if (RefererUrlValidator.isValid(refererUrl)) Some(refererUrl) else None
 }

--- a/app/controllers/actions/AuthAction.scala
+++ b/app/controllers/actions/AuthAction.scala
@@ -17,6 +17,7 @@
 package controllers.actions
 
 import com.google.inject.ProvidedBy
+import config.AppConfig
 import controllers.routes
 import models.AuthKey
 import models.requests.{AuthenticatedRequest, SignedInUser}
@@ -76,7 +77,7 @@ class EoriAllowList(val values: Seq[String]) {
   def allows(eori: String): Boolean = values.isEmpty || values.contains(eori)
 }
 
-class EoriAllowListProvider @Inject()(configuration: Configuration) extends Provider[EoriAllowList] {
+class EoriAllowListProvider @Inject()(config: AppConfig) extends Provider[EoriAllowList] {
   override def get(): EoriAllowList =
-    new EoriAllowList(configuration.get[Seq[String]]("allowList.eori"))
+    new EoriAllowList(config.allowList.eori)
 }

--- a/app/utils/RefererUrlValidator.scala
+++ b/app/utils/RefererUrlValidator.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package utils
+
+import config.AppConfig
+
+object RefererUrlValidator {
+  def isValid(refererUrl: String)(implicit config: AppConfig): Boolean =
+    refersToServiceOnAllowList(refererUrl) && onlyContainsAllowedCharacters(refererUrl)
+
+  private def onlyContainsAllowedCharacters(refererUrl: String): Boolean =
+    refererUrl.matches("^[0-9A-Za-z/_?=&-]+$")
+
+  private def refersToServiceOnAllowList(refererUrl: String)(implicit config: AppConfig): Boolean = {
+    val urlNamespaceParts = refererUrl.split("/").toList
+    urlNamespaceParts match {
+      case first :: serviceName :: _ if (first.isEmpty) =>
+        config.allowList.refererServices.contains(serviceName)
+      case _ => false
+    }
+  }
+}

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -231,7 +231,10 @@ secure-message-answers-repository {
   ttl-seconds = 3600
 }
 
-allowList.eori = []
+allow-list {
+  eori = []
+  referer-services = ["cds-file-upload-service", "customs-declare-exports"]
+}
 
 # Google Tag Manager (GTM) configuration
 tracking-consent-frontend {

--- a/test/base/AppConfigMockHelper.scala
+++ b/test/base/AppConfigMockHelper.scala
@@ -16,27 +16,7 @@
 
 package base
 
-import config.{
-  AppConfig,
-  Assets,
-  CDSFileUpload,
-  CDSFileUploadFrontend,
-  ContactFrontend,
-  CustomsDeclarations,
-  Feedback,
-  FileFormats,
-  FileUploadAnswersRepository,
-  GoogleAnalytics,
-  Keystore,
-  Microservice,
-  Notifications,
-  Platform,
-  Proxy,
-  SecureMessageAnswersRepository,
-  SecureMessaging,
-  Services,
-  TrackingConsentFrontend
-}
+import config._
 import org.scalatestplus.mockito.MockitoSugar
 
 object AppConfigMockHelper extends MockitoSugar {
@@ -53,7 +33,8 @@ object AppConfigMockHelper extends MockitoSugar {
     answersRepository: FileUploadAnswersRepository = mock[FileUploadAnswersRepository],
     secureMessageAnswersRepository: SecureMessageAnswersRepository = mock[SecureMessageAnswersRepository],
     trackingConsentFrontend: TrackingConsentFrontend = mock[TrackingConsentFrontend],
-    platform: Platform = mock[Platform]
+    platform: Platform = mock[Platform],
+    allowList: AllowList = mock[AllowList]
   ) = AppConfig(
     appName,
     developerHubClientId,
@@ -67,7 +48,8 @@ object AppConfigMockHelper extends MockitoSugar {
     answersRepository,
     secureMessageAnswersRepository,
     trackingConsentFrontend,
-    platform
+    platform,
+    allowList
   )
 
   def generateMockServices(

--- a/test/config/AppConfigSpec.scala
+++ b/test/config/AppConfigSpec.scala
@@ -22,7 +22,151 @@ import pureconfig.generic.auto._
 
 class AppConfigSpec extends PlaySpec {
 
-  val config = ConfigSource.default.loadOrThrow[AppConfig]
+  val config =
+    ConfigSource.string("""
+      |appName="cds-file-upload-frontend"
+      |developerHubClientId="cds-file-upload-frontend"
+      |
+      |google-analytics {
+      |  token=N/A
+      |  host=auto
+      |}
+      |
+      |microservice {
+      |  metrics {
+      |    graphite {
+      |      host = localhost
+      |      port = 2003
+      |      prefix = play.appName
+      |      enabled = false
+      |    }
+      |  }
+      |
+      |  services {
+      |    auth {
+      |      host = localhost
+      |      port = 8500
+      |    }
+      |
+      |    keystore {
+      |      protocol = http
+      |      host = localhost
+      |      port = 8400
+      |      default-source = appName
+      |      domain = keystore
+      |    }
+      |
+      |    customs-declarations {
+      |      protocol = http
+      |      host = localhost
+      |      port = 6793
+      |      batch-upload-uri = /cds-file-upload-service/test-only/batch-file-upload
+      |      api-version = "3.0"
+      |    }
+      |
+      |    cds-file-upload-frontend {
+      |      protocol = http
+      |      host = localhost
+      |      port = 6793
+      |    }
+      |
+      |    cds-file-upload {
+      |      protocol = http
+      |      host = localhost
+      |      port = 6795
+      |      fetch-notification-uri = /cds-file-upload/notification
+      |      fetch-declaration-status = /cds-file-upload/declaration-information
+      |      fetch-verified-email = /cds-file-upload/eori-email
+      |    }
+      |
+      |    contact-frontend {
+      |      url = "http://localhost:9250/contact/beta-feedback-unauthenticated"
+      |      service-id = "SFUS"
+      |    }
+      |
+      |    secure-messaging {
+      |      protocol = http
+      |      host = localhost
+      |      port = 9055
+      |      fetch-inbox = /secure-message-frontend/cds-file-upload-service/messages
+      |      fetch-message = /secure-message-frontend/cds-file-upload-service/conversation
+      |      reply-result = /secure-message-frontend/cds-file-upload-service/conversation/CLIENT_ID/CONVERSATION_ID/result
+      |      submit-reply = /secure-message-frontend/cds-file-upload-service/conversation
+      |    }
+      |
+      |    features {
+      |      default = disabled
+      |      secureMessaging = enabled
+      |    }
+      |  }
+      |}
+      |
+      |proxy {
+      |  protocol = https
+      |  host = outbound-proxy-vip
+      |  port = 3128
+      |  username = cds-file-upload-frontend
+      |  password = na
+      |  proxy-required-for-this-environment = false
+      |}
+      |
+      |assets {
+      |  version = "3.7.0"
+      |  version = "1.0.0"
+      |  url = "http://localhost:9032/assets/"
+      |}
+      |
+      |file-formats {
+      |  max-file-size-mb = 10
+      |  approved-file-extensions = ".jpeg,.jpg,.png,.pdf,.txt"
+      |  approved-file-types = "image/jpeg,image/png,application/pdf,text/plain"
+      |}
+      |
+      |# ttl cannot be changed after initial deployment without manually dropping the index
+      |notifications {
+      |  max-retries = 1000
+      |  retry-pause-millis = 250
+      |}
+      |
+      |feedback {
+      |  url = "http://localhost:9514/feedback/FUS"
+      |}
+      |
+      |accessibility-statement.service-path = "/cds-file-upload"
+      |
+      |urls {
+      |  login = "http://localhost:9949/auth-login-stub/gg-sign-in"
+      |  loginContinue = "http://localhost:6793/cds-file-upload-service/start"
+      |  eoriService = "https://www.gov.uk/eori"
+      |  cdsRegister = "https://www.gov.uk/guidance/get-access-to-the-customs-declaration-service"
+      |  cdsCheckStatus = "https://www.tax.service.gov.uk/customs/register-for-cds/are-you-based-in-uk"
+      |  feedbackFrontend = "http://locahost:9514/feedback/cds-file-upload-frontend"
+      |  nationalClearingHubLink = "mailto:nch.cds@hmrc.gov.uk"
+      |  emailFrontendUrl = "http://localhost:9898/manage-email-cds/service/cds-file-upload"
+      |}
+      |
+      |file-upload-answers-repository {
+      |  ttl-seconds = 3600
+      |}
+      |
+      |secure-message-answers-repository {
+      |  ttl-seconds = 3600
+      |}
+      |
+      |allow-list {
+      |  eori = [123456,345678]
+      |  referer-services = ["cds-file-upload-service", "customs-declare-exports"]
+      |}
+      |
+      |tracking-consent-frontend {
+      |  gtm.container = "a"
+      |  url = "http://localhost:12345/tracking-consent/tracking.js"
+      |}
+      |
+      |# Default value for local environment
+      |platform.frontend.host = "http://localhost:6793"
+      |
+    """.stripMargin).loadOrThrow[AppConfig]
 
   "App Config" should {
 
@@ -83,6 +227,14 @@ class AppConfigSpec extends PlaySpec {
 
     "have a TTL defined for the SecureMessageAnswersRepository" in {
       config.secureMessageAnswersRepository.ttlSeconds mustBe 3600
+    }
+
+    "have an allow list eori value defined" in {
+      config.allowList.eori.size mustBe 2
+    }
+
+    "have an allow list refererServices value defined" in {
+      config.allowList.refererServices.size mustBe 2
     }
   }
 }

--- a/test/controllers/MrnEntryControllerSpec.scala
+++ b/test/controllers/MrnEntryControllerSpec.scala
@@ -48,18 +48,17 @@ class MrnEntryControllerSpec extends ControllerSpecBase {
       mrnDisValidator,
       mrnAccessDeniedPage,
       secureMessagingConfig
-    )(executionContext)
+    )(executionContext, appConfig)
 
   override def beforeEach(): Unit = {
     super.beforeEach()
-
     reset(mrnEntryPage, mrnAccessDeniedPage, mrnDisValidator, secureMessagingConfig)
     when(mrnEntryPage.apply(any(), any())(any(), any())).thenReturn(HtmlFormat.empty)
     when(mrnAccessDeniedPage.apply(any())(any(), any())).thenReturn(HtmlFormat.empty)
     when(secureMessagingConfig.isSecureMessagingEnabled).thenReturn(true)
   }
 
-  val validUrl = "https://www.google.com"
+  val validRefererUrl = "/cds-file-upload-service/conversation/CDCM/TEST-kWZYP-9cZCw9Dw"
 
   "MrnEntryController on onPageLoad" should {
 
@@ -88,7 +87,7 @@ class MrnEntryControllerSpec extends ControllerSpecBase {
     "no value is sent in the request" should {
 
       "not update the mrnPageRefererUrl value in the cache" in {
-        val controller = mrnEntryController(validAnswers.copy(mrnPageRefererUrl = Some(validUrl)))
+        val controller = mrnEntryController(validAnswers.copy(mrnPageRefererUrl = Some(validRefererUrl)))
 
         controller.onPageLoad()(fakeRequest).futureValue
 
@@ -122,17 +121,49 @@ class MrnEntryControllerSpec extends ControllerSpecBase {
       "update the mrnPageRefererUrl value in the cache" in {
         val controller = mrnEntryController()
 
-        controller.onPageLoad(Some(validUrl))(fakeRequest).futureValue
+        controller.onPageLoad(Some(validRefererUrl))(fakeRequest).futureValue
 
-        theSavedFileUploadAnswers.mrnPageRefererUrl mustBe Some(validUrl)
+        theSavedFileUploadAnswers.mrnPageRefererUrl mustBe Some(validRefererUrl)
       }
 
       "call MrnEntryPage, providing back link url from cache" in {
         val controller = mrnEntryController()
 
-        controller.onPageLoad(Some(validUrl))(fakeRequest).futureValue
+        controller.onPageLoad(Some(validRefererUrl))(fakeRequest).futureValue
 
-        verify(mrnEntryPage).apply(any(), eqTo(Some(validUrl)))(any(), any())
+        verify(mrnEntryPage).apply(any(), eqTo(Some(validRefererUrl)))(any(), any())
+      }
+    }
+
+    "an invalid URL is sent in the request" should {
+      val invalidRefererUrl = "www.google.com"
+
+      "not update the mrnPageRefererUrl value in the cache" in {
+        val controller = mrnEntryController()
+
+        controller.onPageLoad(Some(invalidRefererUrl))(fakeRequest).futureValue
+
+        verifyNoInteractions(mockFileUploadAnswersService)
+      }
+
+      "call MrnEntryPage, providing default back link url" when {
+        "SecureMessaging is enabled" in withSecureMessagingEnabled(enabled = true) {
+          val controller = mrnEntryController()
+
+          controller.onPageLoad(Some(invalidRefererUrl))(fakeRequest).futureValue
+
+          verify(mrnEntryPage).apply(any(), eqTo(Some(routes.ChoiceController.onPageLoad().url)))(any(), any())
+        }
+      }
+
+      "call MrnEntryPage, providing no back link url" when {
+        "SecureMessaging is disabled" in withSecureMessagingEnabled(enabled = false) {
+          val controller = mrnEntryController()
+
+          controller.onPageLoad(Some(invalidRefererUrl))(fakeRequest).futureValue
+
+          verify(mrnEntryPage).apply(any(), eqTo(None))(any(), any())
+        }
       }
     }
   }
@@ -255,13 +286,13 @@ class MrnEntryControllerSpec extends ControllerSpecBase {
   "MrnEntryController on autoFill" should {
     "not clear the mrnPageRefererUrl value in the cache" when {
       "no value is sent in the request" in {
-        val controller = mrnEntryController(validAnswers.copy(mrnPageRefererUrl = Some(validUrl)))
+        val controller = mrnEntryController(validAnswers.copy(mrnPageRefererUrl = Some(validRefererUrl)))
 
         when(mrnDisValidator.validate(any(), any())(any())).thenReturn(Future.successful(true))
 
         controller.autoFill(mrn)(fakeRequest).futureValue
 
-        theSavedFileUploadAnswers.mrnPageRefererUrl mustBe Some(validUrl)
+        theSavedFileUploadAnswers.mrnPageRefererUrl mustBe Some(validRefererUrl)
       }
     }
 
@@ -271,9 +302,9 @@ class MrnEntryControllerSpec extends ControllerSpecBase {
 
         when(mrnDisValidator.validate(any(), any())(any())).thenReturn(Future.successful(true))
 
-        controller.autoFill(mrn, Some(validUrl))(fakeRequest).futureValue
+        controller.autoFill(mrn, Some(validRefererUrl))(fakeRequest).futureValue
 
-        theSavedFileUploadAnswers.mrnPageRefererUrl mustBe Some(validUrl)
+        theSavedFileUploadAnswers.mrnPageRefererUrl mustBe Some(validRefererUrl)
       }
     }
   }

--- a/test/utils/RefererUrlValidatorSpec.scala
+++ b/test/utils/RefererUrlValidatorSpec.scala
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package utils
+
+import base.AppConfigMockHelper.generateMockConfig
+import base.Injector
+import config.AllowList
+import org.scalatestplus.mockito.MockitoSugar
+import org.scalatestplus.play.PlaySpec
+
+class RefererUrlValidatorSpec extends PlaySpec with Injector with MockitoSugar {
+
+  private val allowedService1 = "service1"
+  private val allowedService2 = "service2"
+  private val disallowedService3 = "service3"
+  private val validRefererUrl = s"/$allowedService1/"
+
+  lazy implicit val appConfig = generateMockConfig(allowList = AllowList(List.empty, List(allowedService1, allowedService2)))
+
+  val validator = RefererUrlValidator
+
+  "RefererUrlValidator" should {
+    "allow referer urls that reference the services on the allow list" in {
+      validator.isValid(s"/$allowedService1/") mustBe true
+      validator.isValid(s"/$allowedService2/") mustBe true
+    }
+
+    "deny referer urls that reference the services not on the allow list" in {
+      validator.isValid(s"/$disallowedService3/") mustBe false
+      validator.isValid(s"/something$allowedService1/") mustBe false
+      validator.isValid(s"/something/$allowedService1/") mustBe false
+    }
+
+    "deny referer urls that do not start with a '/'" in {
+      validator.isValid(s"$allowedService1/") mustBe false
+    }
+
+    "deny referer urls that specify a host value" in {
+      validator.isValid(s"www.google.com/$allowedService1/") mustBe false
+    }
+
+    "deny referer urls that specify a protocol" in {
+      validator.isValid(s"javaScript:/$allowedService1/") mustBe false
+    }
+
+    "deny referer urls that contain prohibited ASCII characters" in {
+      val prohibitedChars =
+        Seq('`', '¬', '\'', '!', '"', '£', '$', '%', '^', '*', '(', ')', '+', '[', ']', '{', '}', ';', ':', '@', '#', '~', '<', '>', ',', '.', '\\')
+
+      prohibitedChars.foreach(
+        char =>
+          withClue(s"including char '${char}'") {
+            validator.isValid(s"${validRefererUrl}${char}") mustBe false
+        }
+      )
+    }
+
+    "allow referer urls that contain allowed non-alphanumeric ASCII characters" in {
+      val allowedChars = Seq('_', '-', '/', '?', '&', '=')
+
+      allowedChars.foreach(
+        char =>
+          withClue(s"including char '${char}'") {
+            validator.isValid(s"${validRefererUrl}${char}") mustBe true
+        }
+      )
+    }
+
+    "deny referer urls that contain extended characters" in {
+      val prohibitedChars = Seq('\u200B', '¥', 'ä')
+
+      prohibitedChars.foreach(
+        char =>
+          withClue(s"including char '${char}'") {
+            validator.isValid(s"${validRefererUrl}${char}") mustBe false
+        }
+      )
+    }
+  }
+}


### PR DESCRIPTION
To plug the security vulnerability that was picked up
in the pen test.

We now only allow relative urls that point to an
MDTP service that are on our allow list of services
and that only contain a limited set of ASCII chars.