### PR TITLE
CEDS-3947 - Legend fixes

### DIFF
--- a/app/views/components/gds/pageTitle.scala.html
+++ b/app/views/components/gds/pageTitle.scala.html
@@ -20,9 +20,7 @@
 
 @(text: String, classes: String = gdsPageHeading)
 
-<legend class="@{classes}">
-  <h1 class="govuk-fieldset__heading">
-    @text
-  </h1>
-</legend>
+<h1 class="govuk-fieldset__heading">
+  @text
+</h1>
 

--- a/app/views/components/gds/pageTitle.scala.html
+++ b/app/views/components/gds/pageTitle.scala.html
@@ -18,7 +18,7 @@
 
 @this()
 
-@(text: String, classes: String = gdsPageHeading)
+@(text: String)
 
 <h1 class="govuk-fieldset__heading">
   @text


### PR DESCRIPTION
Removing the legend element from the template - it's not being used properly and isn't needed on most pages in this service.