### PR TITLE
CEDS-3947 - Legend fixes

### DIFF
--- a/app/views/components/gds/pageTitle.scala.html
+++ b/app/views/components/gds/pageTitle.scala.html
@@ -20,9 +20,7 @@
 
 @(text: String, classes: String = gdsPageHeading)
 
-<legend class="@{classes}">
-  <h1 class="govuk-fieldset__heading">
-    @text
-  </h1>
-</legend>
+<h1 class="govuk-fieldset__heading">
+  @text
+</h1>
 

--- a/app/views/components/gds/pageTitle.scala.html
+++ b/app/views/components/gds/pageTitle.scala.html
@@ -18,7 +18,7 @@
 
 @this()
 
-@(text: String, classes: String = gdsPageHeading)
+@(text: String)
 
 <h1 class="govuk-fieldset__heading">
   @text

--- a/app/views/components/gds/pageTitle.scala.html
+++ b/app/views/components/gds/pageTitle.scala.html
@@ -20,7 +20,7 @@
 
 @(text: String)
 
-<h1 class="govuk-fieldset__heading">
+<h1 class="govuk-heading-xl">
   @text
 </h1>
 

--- a/app/views/error_template.scala.html
+++ b/app/views/error_template.scala.html
@@ -27,7 +27,7 @@
 
 @govukLayout(title = Title(title)) {
 
-  @pageTitle(text = messages(heading), classes = "govuk-heading-xl")
+  @pageTitle(text = messages(heading))
   @messageKeys.map { key =>
     <p class="govuk-body-m">@messages(key)</p>
   }


### PR DESCRIPTION
Removing the heading legend as it isn't needed on most pages. Setting the default class to the most relevant for a h1.