### PR TITLE
Ceds 4176 bug error fix

### DIFF
--- a/app/views/upload_your_files.scala.html
+++ b/app/views/upload_your_files.scala.html
@@ -78,8 +78,7 @@
         }.map(msg => <p class="govuk-body"><strong>{msg}</strong></p>)
     }
 
-    @formHelper(Call("POST", uploadRequest.href), args = Symbol("enctype") -> "multipart/form-data") {
-
+    <form action="@uploadRequest.href" method="POST" enctype="multipart/form-data">
         <div class="govuk-form-group">
             @uploadRequest.fields.map { case (key, value) =>
                 <input type="hidden" name="@key" value="@value"/>
@@ -106,7 +105,7 @@
             text = messages("fileUploadPage.cancel"),
             call = routes.HowManyFilesUploadController.onPageLoad
         )
-    }
+    </form>
 }
 
 <script src="@routes.Assets.versioned("javascripts/validation.min.js")"></script>

--- a/app/views/upload_your_files.scala.html
+++ b/app/views/upload_your_files.scala.html
@@ -87,7 +87,7 @@
 
             @govukFileUpload(FileUploadComponent(
                 id = fileUploadId,
-                name = fileUploadId,
+                name = "file",
                 label = Label(content = Text(messages("fileUploadPage.label"))),
                 attributes = Map(
                     "accept" -> appConfig.fileFormats.approvedFileTypes,


### PR DESCRIPTION
Fixed the issue with Upscan returning 'Bad file' error notification.

Issue was a combination of the `name` attribute of the input form element not being set to 'file' and the unnecessary inclusion of a CSRF token hidden input element that Upscan was not expecting.