### PR TITLE
CEDS-6153 Multiple issues with error handling on file upload page

### DIFF
--- a/app/views/upload_your_files.scala.html
+++ b/app/views/upload_your_files.scala.html
@@ -47,13 +47,7 @@
 @fileUploadId = @{"file-upload-component"}
 
 @mainTemplate(title = Title(s"fileUploadPage.heading.$positionModifier")) {
-    @govukErrorSummary(
-        ErrorSummary(
-            classes = "govuk-visually-hidden",
-            errorList = List.empty,
-            title = Text(messages("error.summary.title"))
-        )
-    )
+    <div class="govuk-error-summary govuk-visually-hidden" data-module="govuk-error-summary"></div>
 
     <span class="govuk-caption-l">@{mrn.value}</span>
     @pageTitle(text = messages(s"fileUploadPage.heading.$positionModifier"))
@@ -107,13 +101,15 @@
         )
     </form>
 }
-<script @CSPNonce.attr id="validation" src="@routes.Assets.versioned("javascripts/validation.js")"></script>
 <script @CSPNonce.attr id="validation-messages" type="text/javascript">
 window.messages = {
         "fileUploadPage.error.nameStart": "@messages("fileUploadPage.error.nameStart")",
         "fileUploadPage.error.fileSize" : "@messages("fileUploadPage.error.fileSize")",
         "fileUploadPage.error.extension" : "@messages("fileUploadPage.error.extension")",
         "fileUploadPage.selectFile" : "@messages("fileUploadPage.error.selectFile")",
-        "fileUploadPage.error.emptyFile": "@messages("fileUploadPage.error.emptyFile")"
+        "fileUploadPage.error.emptyFile": "@messages("fileUploadPage.error.emptyFile")",
+        "global.error.title": "@messages("global.error.title")",
+        "error.browser.heading.prefix": "@messages("error.browser.heading.prefix")"
 }
 </script>
+<script @CSPNonce.attr id="validation" src="@routes.Assets.versioned("javascripts/validation.js")"></script>


### PR DESCRIPTION
On initial page load there is no visually hidden error message in page. 
Set page title to include 'Error:' prefix if error is present on page. 
Focus is set to error summary link when error present. 
Stop disabling of form submit button (validation now only takes place when user clicks submit button). 
Added visually hidden 'Error:' prefix to form element error text.